### PR TITLE
Improve collection of dataset usages and citation on occurrence downloads 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <commons-validator.version>1.5.1</commons-validator.version>
     <findbugs-jsr305.version>3.0.1</findbugs-jsr305.version>
     <freemarker.version>2.3.25-incubating</freemarker.version>
-    <gbif-api.version>0.69</gbif-api.version>
+    <gbif-api.version>0.70-SNAPSHOT</gbif-api.version>
     <gbif-cli.version>0.10</gbif-cli.version>
     <gbif-common-mybatis.version>0.28</gbif-common-mybatis.version>
     <gbif-common-search.version>0.33</gbif-common-search.version>

--- a/registry-ws-client/src/main/java/org/gbif/registry/ws/client/DatasetOccurrenceDownloadUsageWsClient.java
+++ b/registry-ws-client/src/main/java/org/gbif/registry/ws/client/DatasetOccurrenceDownloadUsageWsClient.java
@@ -20,7 +20,7 @@ import com.sun.jersey.api.client.filter.ClientFilter;
 public class DatasetOccurrenceDownloadUsageWsClient extends BaseWsGetClient<Download, String> implements
   DatasetOccurrenceDownloadUsageService {
 
-  private static final String DATASET = "dataset";
+  private static final String DATASET_PATH = "dataset";
   
   @Inject
   public DatasetOccurrenceDownloadUsageWsClient(@RegistryWs WebResource resource, @Nullable ClientFilter authFilter) {
@@ -29,6 +29,6 @@ public class DatasetOccurrenceDownloadUsageWsClient extends BaseWsGetClient<Down
 
   @Override
   public PagingResponse<DatasetOccurrenceDownloadUsage> listByDataset(UUID datasetKey, Pageable page) {
-    return get(GenericTypes.PAGING_DATASET_OCCURRENCE_DOWNLOAD, page, DATASET, String.valueOf(datasetKey));
+    return get(GenericTypes.PAGING_DATASET_OCCURRENCE_DOWNLOAD, page, DATASET_PATH, String.valueOf(datasetKey));
   }
 }

--- a/registry-ws-client/src/main/java/org/gbif/registry/ws/client/DatasetOccurrenceDownloadUsageWsClient.java
+++ b/registry-ws-client/src/main/java/org/gbif/registry/ws/client/DatasetOccurrenceDownloadUsageWsClient.java
@@ -7,7 +7,6 @@ import org.gbif.api.model.registry.DatasetOccurrenceDownloadUsage;
 import org.gbif.api.service.registry.DatasetOccurrenceDownloadUsageService;
 import org.gbif.registry.ws.client.guice.RegistryWs;
 import org.gbif.ws.client.BaseWsGetClient;
-import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -31,10 +30,5 @@ public class DatasetOccurrenceDownloadUsageWsClient extends BaseWsGetClient<Down
   @Override
   public PagingResponse<DatasetOccurrenceDownloadUsage> listByDataset(UUID datasetKey, Pageable page) {
     return get(GenericTypes.PAGING_DATASET_OCCURRENCE_DOWNLOAD, page, DATASET, String.valueOf(datasetKey));
-  }
-
-  @Override
-  public void bulkCreate(List<DatasetOccurrenceDownloadUsage> downloadDataset) {
-    post(downloadDataset, DATASET);
   }
 }

--- a/registry-ws-client/src/main/java/org/gbif/registry/ws/client/DatasetOccurrenceDownloadUsageWsClient.java
+++ b/registry-ws-client/src/main/java/org/gbif/registry/ws/client/DatasetOccurrenceDownloadUsageWsClient.java
@@ -7,7 +7,7 @@ import org.gbif.api.model.registry.DatasetOccurrenceDownloadUsage;
 import org.gbif.api.service.registry.DatasetOccurrenceDownloadUsageService;
 import org.gbif.registry.ws.client.guice.RegistryWs;
 import org.gbif.ws.client.BaseWsGetClient;
-
+import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nullable;
 
@@ -21,19 +21,20 @@ import com.sun.jersey.api.client.filter.ClientFilter;
 public class DatasetOccurrenceDownloadUsageWsClient extends BaseWsGetClient<Download, String> implements
   DatasetOccurrenceDownloadUsageService {
 
+  private static final String DATASET = "dataset";
+  
   @Inject
   public DatasetOccurrenceDownloadUsageWsClient(@RegistryWs WebResource resource, @Nullable ClientFilter authFilter) {
     super(Download.class, resource.path("occurrence/download"), authFilter);
   }
 
   @Override
-  public void create(DatasetOccurrenceDownloadUsage downloadDataset) {
-    post(downloadDataset, "dataset");
+  public PagingResponse<DatasetOccurrenceDownloadUsage> listByDataset(UUID datasetKey, Pageable page) {
+    return get(GenericTypes.PAGING_DATASET_OCCURRENCE_DOWNLOAD, page, DATASET, String.valueOf(datasetKey));
   }
 
   @Override
-  public PagingResponse<DatasetOccurrenceDownloadUsage> listByDataset(UUID datasetKey, Pageable page) {
-    return get(GenericTypes.PAGING_DATASET_OCCURRENCE_DOWNLOAD, page, "dataset", String.valueOf(datasetKey));
+  public void bulkCreate(List<DatasetOccurrenceDownloadUsage> downloadDataset) {
+    post(downloadDataset, DATASET);
   }
-
 }

--- a/registry-ws-client/src/main/java/org/gbif/registry/ws/client/OccurrenceDownloadWsClient.java
+++ b/registry-ws-client/src/main/java/org/gbif/registry/ws/client/OccurrenceDownloadWsClient.java
@@ -104,4 +104,9 @@ public class OccurrenceDownloadWsClient extends BaseWsGetClient<Download, String
     Optional.ofNullable(datasetKey).ifPresent( dk -> params.add("datasetKey", dk.toString()));
     return get(GenericTypes.DOWNLOADS_STATS_TYPE, null, params ,null,path);
   }
+
+  @Override
+  public void createUsages(String downloadKey, Map<UUID, Long> datasetCitations) {
+    post(datasetCitations,downloadKey+"/datasets");
+  }
 }

--- a/registry-ws-client/src/main/java/org/gbif/registry/ws/client/OccurrenceDownloadWsClient.java
+++ b/registry-ws-client/src/main/java/org/gbif/registry/ws/client/OccurrenceDownloadWsClient.java
@@ -107,6 +107,6 @@ public class OccurrenceDownloadWsClient extends BaseWsGetClient<Download, String
 
   @Override
   public void createUsages(String downloadKey, Map<UUID, Long> datasetCitations) {
-    post(datasetCitations,downloadKey+"/datasets");
+    post(datasetCitations, downloadKey + "/datasets");
   }
 }

--- a/registry-ws/src/main/java/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.java
+++ b/registry-ws/src/main/java/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.java
@@ -18,15 +18,12 @@ import org.gbif.api.model.registry.DatasetOccurrenceDownloadUsage;
 import java.util.List;
 import java.util.UUID;
 import javax.annotation.Nullable;
-
 import org.apache.ibatis.annotations.Param;
 
 /**
  * Mapper that perform operations on dataset usages in occurrence downloads.
  */
 public interface DatasetOccurrenceDownloadMapper {
-
-  void create(DatasetOccurrenceDownloadUsage downloadDataset);
 
   List<DatasetOccurrenceDownloadUsage> listByDataset(@Param("datasetKey") UUID datasetKey,
     @Nullable @Param("page") Pageable page);
@@ -35,4 +32,6 @@ public interface DatasetOccurrenceDownloadMapper {
 
   List<DatasetOccurrenceDownloadUsage> listByDownload(@Param("downloadKey") String downloadKey,
                                                      @Nullable @Param("page") Pageable page);
+  
+  void bulkCreate(List<DatasetOccurrenceDownloadUsage> downloadDataset);
 }

--- a/registry-ws/src/main/java/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.java
+++ b/registry-ws/src/main/java/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.java
@@ -34,5 +34,5 @@ public interface DatasetOccurrenceDownloadMapper {
   List<DatasetOccurrenceDownloadUsage> listByDownload(@Param("downloadKey") String downloadKey,
                                                      @Nullable @Param("page") Pageable page);
   
-  void createUsages(@Param("downloadkey")String downloadkey,@Param("citationMap")Map<UUID,Long> downloadDataset);
+  void createUsages(@Param("downloadkey") String downloadkey, @Param("citationMap") Map<UUID,Long> downloadDataset);
 }

--- a/registry-ws/src/main/java/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.java
+++ b/registry-ws/src/main/java/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.java
@@ -16,6 +16,7 @@ import org.gbif.api.model.common.paging.Pageable;
 import org.gbif.api.model.registry.DatasetOccurrenceDownloadUsage;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.ibatis.annotations.Param;
@@ -33,5 +34,5 @@ public interface DatasetOccurrenceDownloadMapper {
   List<DatasetOccurrenceDownloadUsage> listByDownload(@Param("downloadKey") String downloadKey,
                                                      @Nullable @Param("page") Pageable page);
   
-  void bulkCreate(List<DatasetOccurrenceDownloadUsage> downloadDataset);
+  void createUsages(@Param("downloadkey")String downloadkey,@Param("citationMap")Map<UUID,Long> downloadDataset);
 }

--- a/registry-ws/src/main/java/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.java
+++ b/registry-ws/src/main/java/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.java
@@ -34,5 +34,5 @@ public interface DatasetOccurrenceDownloadMapper {
   List<DatasetOccurrenceDownloadUsage> listByDownload(@Param("downloadKey") String downloadKey,
                                                      @Nullable @Param("page") Pageable page);
   
-  void createUsages(@Param("downloadkey") String downloadkey, @Param("citationMap") Map<UUID,Long> downloadDataset);
+  void createUsages(@Param("downloadkey") String downloadKey, @Param("citationMap") Map<UUID,Long> downloadDataset);
 }

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetOccurrenceDownloadUsageResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetOccurrenceDownloadUsageResource.java
@@ -8,7 +8,6 @@ import org.gbif.api.service.registry.DatasetOccurrenceDownloadUsageService;
 import org.gbif.registry.persistence.mapper.DatasetOccurrenceDownloadMapper;
 import org.gbif.ws.server.interceptor.NullToNotFound;
 import org.gbif.ws.util.ExtraMediaTypes;
-
 import java.util.List;
 import java.util.UUID;
 import javax.annotation.security.RolesAllowed;
@@ -52,16 +51,6 @@ public class DatasetOccurrenceDownloadUsageResource implements DatasetOccurrence
     this.datasetOccurrenceDownloadMapper = datasetOccurrenceDownloadMapper;
   }
 
-
-  @POST
-  @Transactional
-  @Validate(groups = {PrePersist.class, Default.class})
-  @RolesAllowed(ADMIN_ROLE)
-  @Override
-  public void create(@Valid @NotNull DatasetOccurrenceDownloadUsage downloadDataset) {
-    datasetOccurrenceDownloadMapper.create(downloadDataset);
-  }
-
   @GET
   @Path("/{datasetKey}")
   @NullToNotFound
@@ -72,6 +61,15 @@ public class DatasetOccurrenceDownloadUsageResource implements DatasetOccurrence
     clearSensitiveData(securityContext, usages);
     return new PagingResponse<>(page,
       (long) datasetOccurrenceDownloadMapper.countByDataset(datasetKey), usages);
+  }
+  
+  @POST
+  @Transactional
+  @Validate(groups = {PrePersist.class, Default.class})
+  @RolesAllowed(ADMIN_ROLE)
+  @Override
+  public void bulkCreate(@Valid @NotNull List<DatasetOccurrenceDownloadUsage> downloadDataset) {
+     datasetOccurrenceDownloadMapper.bulkCreate(downloadDataset);
   }
 
 }

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetOccurrenceDownloadUsageResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetOccurrenceDownloadUsageResource.java
@@ -3,7 +3,6 @@ package org.gbif.registry.ws.resources;
 import org.gbif.api.model.common.paging.Pageable;
 import org.gbif.api.model.common.paging.PagingResponse;
 import org.gbif.api.model.registry.DatasetOccurrenceDownloadUsage;
-import org.gbif.api.model.registry.PrePersist;
 import org.gbif.api.service.registry.DatasetOccurrenceDownloadUsageService;
 import org.gbif.registry.persistence.mapper.DatasetOccurrenceDownloadMapper;
 import org.gbif.ws.server.interceptor.NullToNotFound;

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetOccurrenceDownloadUsageResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetOccurrenceDownloadUsageResource.java
@@ -10,13 +10,8 @@ import org.gbif.ws.server.interceptor.NullToNotFound;
 import org.gbif.ws.util.ExtraMediaTypes;
 import java.util.List;
 import java.util.UUID;
-import javax.annotation.security.RolesAllowed;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-import javax.validation.groups.Default;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
-import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
@@ -26,10 +21,6 @@ import javax.ws.rs.core.SecurityContext;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.apache.bval.guice.Validate;
-import org.mybatis.guice.transactional.Transactional;
-
-import static org.gbif.registry.ws.security.UserRoles.ADMIN_ROLE;
 import static org.gbif.registry.ws.util.DownloadSecurityUtils.clearSensitiveData;
 
 /**
@@ -61,15 +52,6 @@ public class DatasetOccurrenceDownloadUsageResource implements DatasetOccurrence
     clearSensitiveData(securityContext, usages);
     return new PagingResponse<>(page,
       (long) datasetOccurrenceDownloadMapper.countByDataset(datasetKey), usages);
-  }
-  
-  @POST
-  @Transactional
-  @Validate(groups = {PrePersist.class, Default.class})
-  @RolesAllowed(ADMIN_ROLE)
-  @Override
-  public void bulkCreate(@Valid @NotNull List<DatasetOccurrenceDownloadUsage> downloadDataset) {
-     datasetOccurrenceDownloadMapper.bulkCreate(downloadDataset);
   }
 
 }

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/OccurrenceDownloadResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/OccurrenceDownloadResource.java
@@ -168,6 +168,16 @@ public class OccurrenceDownloadResource implements OccurrenceDownloadService {
     }
     throw new NotFoundException();
   }
+  
+  @POST
+  @Path("{key}/datasets")
+  @Transactional
+  @Validate(groups = {PrePersist.class, Default.class})
+  @RolesAllowed(ADMIN_ROLE)
+  @Override
+  public void createUsages(@PathParam("key") String downloadkey,@Valid @NotNull Map<UUID,Long> datasetCitations) {
+    datasetOccurrenceDownloadMapper.createUsages(downloadkey, datasetCitations);
+  }
 
   @GET
   @Path("statistics/downloadsByUserCountry")

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/OccurrenceDownloadResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/OccurrenceDownloadResource.java
@@ -175,8 +175,8 @@ public class OccurrenceDownloadResource implements OccurrenceDownloadService {
   @Validate(groups = {PrePersist.class, Default.class})
   @RolesAllowed(ADMIN_ROLE)
   @Override
-  public void createUsages(@PathParam("key") String downloadkey, @Valid @NotNull Map<UUID,Long> datasetCitations) {
-    datasetOccurrenceDownloadMapper.createUsages(downloadkey, datasetCitations);
+  public void createUsages(@PathParam("key") String downloadKey, @Valid @NotNull Map<UUID,Long> datasetCitations) {
+    datasetOccurrenceDownloadMapper.createUsages(downloadKey, datasetCitations);
   }
 
   @GET

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/OccurrenceDownloadResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/OccurrenceDownloadResource.java
@@ -175,7 +175,7 @@ public class OccurrenceDownloadResource implements OccurrenceDownloadService {
   @Validate(groups = {PrePersist.class, Default.class})
   @RolesAllowed(ADMIN_ROLE)
   @Override
-  public void createUsages(@PathParam("key") String downloadkey,@Valid @NotNull Map<UUID,Long> datasetCitations) {
+  public void createUsages(@PathParam("key") String downloadkey, @Valid @NotNull Map<UUID,Long> datasetCitations) {
     datasetOccurrenceDownloadMapper.createUsages(downloadkey, datasetCitations);
   }
 

--- a/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
+++ b/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
@@ -41,20 +41,19 @@
     FROM dataset_occurrence_download
     WHERE dataset_key = #{datasetKey,jdbcType=OTHER}
   </select>
-
-  <insert id="bulkCreate" parameterType="java.util.List">
-    INSERT INTO dataset_occurrence_download(download_key,dataset_key,dataset_title,dataset_doi,dataset_citation,number_records)
-    VALUES
-     <foreach item="item" collection="list" separator=",">
-     (
-     #{item.downloadKey,jdbcType=VARCHAR},
-     #{item.datasetKey,jdbcType=OTHER},
-     #{item.datasetTitle,jdbcType=VARCHAR},
-     #{item.datasetDOI,jdbcType=VARCHAR},
-     #{item.datasetCitation,jdbcType=VARCHAR},
-     #{item.numberRecords,jdbcType=INTEGER}
-    )
-    </foreach>
+  
+  <insert id="createUsages">
+    INSERT INTO dataset_occurrence_download ( 
+    WITH dataset_usages(dataset_key, number_records) AS
+	((VALUES
+	<foreach item="value" index="key" collection="citationMap" open="(" separator="),(" close=")">
+	cast(#{key} as uuid),#{value}
+	</foreach>
+	))
+	SELECT #{downloadkey} as download_key, dataset.key, number_records, title, doi, citation 
+	FROM dataset 
+	JOIN dataset_usages ON dataset.key = dataset_usages.dataset_key
+	);
   </insert>
 
 </mapper>

--- a/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
+++ b/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
@@ -43,17 +43,18 @@
   </select>
   
   <insert id="createUsages">
-    INSERT INTO dataset_occurrence_download ( 
-    WITH dataset_usages(dataset_key, number_records) AS
+	INSERT INTO dataset_occurrence_download (
+	WITH dataset_usages(dataset_key, number_records) AS
 	((VALUES
-	<foreach item="value" index="key" collection="citationMap" open="(" separator="),(" close=")">
-	cast(#{key} as uuid),#{value}
+	<foreach item="value" index="key" collection="citationMap"
+		open="(" separator="),(" close=")">
+		cast(#{key} as uuid),#{value}
 	</foreach>
 	))
-	SELECT #{downloadkey} as download_key, dataset.key, number_records, title, doi, citation 
-	FROM dataset 
-	JOIN dataset_usages ON dataset.key = dataset_usages.dataset_key
-	);
-  </insert>
+	SELECT #{downloadkey} as download_key, dataset.key, number_records,
+	title, doi, citation
+	FROM dataset
+	JOIN dataset_usages ON dataset.key = dataset_usages.dataset_key);
+</insert>
 
 </mapper>

--- a/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
+++ b/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
@@ -44,15 +44,14 @@
   
   <insert id="createUsages">
 	INSERT INTO dataset_occurrence_download (
-	WITH dataset_usages(dataset_key, number_records) AS
+	WITH
+	dataset_usages(dataset_key, number_records) AS
 	((VALUES
-	<foreach item="value" index="key" collection="citationMap"
-		open="(" separator="),(" close=")">
+	<foreach item="value" index="key" collection="citationMap" open="(" separator="),(" close=")">
 		cast(#{key} as uuid),#{value}
 	</foreach>
 	))
-	SELECT #{downloadkey} as download_key, dataset.key, number_records,
-	title, doi, citation
+	SELECT #{downloadkey} as download_key, dataset.key, number_records, title, doi, citation
 	FROM dataset
 	JOIN dataset_usages ON dataset.key = dataset_usages.dataset_key);
 </insert>

--- a/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
+++ b/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
@@ -16,18 +16,6 @@
     download_key,dataset_key,dataset_title,dataset_doi,dataset_citation,number_records,<include refid="org.gbif.registry.persistence.mapper.OccurrenceDownloadMapper.OCCURRENCE_DOWNLOAD_FIELDS"/>
   </sql>
 
-  <insert id="create" parameterType="DatasetOccurrenceDownload">
-    INSERT INTO dataset_occurrence_download(download_key,dataset_key,dataset_title,dataset_doi,dataset_citation,number_records)
-    VALUES(
-     #{downloadKey,jdbcType=VARCHAR},
-     #{datasetKey,jdbcType=OTHER},
-     #{datasetTitle,jdbcType=VARCHAR},
-     #{datasetDOI,jdbcType=VARCHAR},
-     #{datasetCitation,jdbcType=VARCHAR},
-     #{numberRecords,jdbcType=INTEGER}
-    )
-  </insert>
-
   <select id="listByDataset" resultMap="DATASET_OCCURRENCE_DOWNLOAD_MAP" parameterType="Pageable">
     SELECT <include refid="DATASET_OCCURRENCE_DOWNLOAD_FIELDS"/>
     FROM dataset_occurrence_download JOIN occurrence_download ON download_key = key
@@ -53,5 +41,20 @@
     FROM dataset_occurrence_download
     WHERE dataset_key = #{datasetKey,jdbcType=OTHER}
   </select>
+
+  <insert id="bulkCreate" parameterType="java.util.List">
+    INSERT INTO dataset_occurrence_download(download_key,dataset_key,dataset_title,dataset_doi,dataset_citation,number_records)
+    VALUES
+     <foreach item="item" collection="list" separator=",">
+     (
+     #{item.downloadKey,jdbcType=VARCHAR},
+     #{item.datasetKey,jdbcType=OTHER},
+     #{item.datasetTitle,jdbcType=VARCHAR},
+     #{item.datasetDOI,jdbcType=VARCHAR},
+     #{item.datasetCitation,jdbcType=VARCHAR},
+     #{item.numberRecords,jdbcType=INTEGER}
+    )
+    </foreach>
+  </insert>
 
 </mapper>

--- a/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
+++ b/registry-ws/src/main/resources/org/gbif/registry/persistence/mapper/DatasetOccurrenceDownloadMapper.xml
@@ -51,7 +51,7 @@
 		cast(#{key} as uuid),#{value}
 	</foreach>
 	))
-	SELECT #{downloadkey} as download_key, dataset.key, number_records, title, doi, citation
+	SELECT #{downloadKey} as download_key, dataset.key, number_records, title, doi, citation
 	FROM dataset
 	JOIN dataset_usages ON dataset.key = dataset_usages.dataset_key);
 </insert>

--- a/registry-ws/src/test/java/org/gbif/registry/DatasetOccurrenceDownloadIT.java
+++ b/registry-ws/src/test/java/org/gbif/registry/DatasetOccurrenceDownloadIT.java
@@ -169,7 +169,7 @@ public class DatasetOccurrenceDownloadIT {
       datasetOccurrenceDownloadUsageService.listByDataset(testDataset.getKey(), new PagingRequest(0, 3))
         .getResults().size());
     Download occDownload2 = occurrenceDownloadService.get(occurrenceDownload.getKey());
-    assertEquals(occDownload2.getNumberDatasets(), 1);
+    assertEquals(1,occDownload2.getNumberDatasets());
   }
   
   /**
@@ -200,7 +200,7 @@ public class DatasetOccurrenceDownloadIT {
         datasetOccurrenceDownloadUsageService.listByDataset(testDataset3.getKey(), new PagingRequest(0, 3))
           .getResults().size());
     Download occDownload2 = occurrenceDownloadService.get(occurrenceDownload.getKey());
-    assertEquals(occDownload2.getNumberDatasets(), 3);
+    assertEquals(3,occDownload2.getNumberDatasets());
   }
 
 }

--- a/registry-ws/src/test/java/org/gbif/registry/DatasetOccurrenceDownloadIT.java
+++ b/registry-ws/src/test/java/org/gbif/registry/DatasetOccurrenceDownloadIT.java
@@ -41,7 +41,7 @@ import org.gbif.registry.ws.resources.NodeResource;
 import org.gbif.registry.ws.resources.OccurrenceDownloadResource;
 import org.gbif.registry.ws.resources.OrganizationResource;
 import org.gbif.ws.client.filter.SimplePrincipalProvider;
-
+import java.util.Arrays;
 import java.util.UUID;
 
 import com.google.common.collect.ImmutableList;
@@ -157,7 +157,7 @@ public class DatasetOccurrenceDownloadIT {
    * Tests the process of persist a {@link DatasetOccurrenceDownload} and list the downloads by dataset key.
    */
   @Test
-  public void testAddAndGetOccurrenceDataset() {
+  public void testAddAndGetOccurrenceDatasetOne() {
     Download occurrenceDownload = OccurrenceDownloadIT.getTestInstance();
     final Dataset testDataset = createTestDataset();
     DatasetOccurrenceDownloadUsage downloadDataset = new DatasetOccurrenceDownloadUsage();
@@ -168,12 +168,49 @@ public class DatasetOccurrenceDownloadIT {
     downloadDataset.setDatasetDOI(new DOI("doi:10.1234/1ASCDU"));
     downloadDataset.setDatasetCitation(testDataset.getCitation().getText());
     occurrenceDownloadService.create(occurrenceDownload);
-    datasetOccurrenceDownloadUsageService.create(downloadDataset);
+    datasetOccurrenceDownloadUsageService.bulkCreate(Arrays.asList(downloadDataset));
     assertEquals("List operation should return 1 record", 1,
       datasetOccurrenceDownloadUsageService.listByDataset(testDataset.getKey(), new PagingRequest(0, 3))
         .getResults().size());
     Download occDownload2 = occurrenceDownloadService.get(occurrenceDownload.getKey());
     assertEquals(occDownload2.getNumberDatasets(), 1);
+  }
+  
+  /**
+   * Tests the process of persist a list of {@link DatasetOccurrenceDownload} and list the downloads by dataset key.
+   */
+  @Test
+  public void testAddAndGetOccurrenceDatasetMany() {
+    Download occurrenceDownload = OccurrenceDownloadIT.getTestInstance();
+    final Dataset testDataset1 = createTestDataset();
+    final Dataset testDataset2 = createTestDataset();
+    
+    DatasetOccurrenceDownloadUsage downloadDataset1 = new DatasetOccurrenceDownloadUsage();
+    downloadDataset1.setDownloadKey(occurrenceDownload.getKey());
+    downloadDataset1.setDatasetKey(testDataset1.getKey());
+    downloadDataset1.setNumberRecords(1000L);
+    downloadDataset1.setDatasetTitle(testDataset1.getTitle());
+    downloadDataset1.setDatasetDOI(new DOI("doi:10.1234/1ASCDU"));
+    downloadDataset1.setDatasetCitation(testDataset1.getCitation().getText());
+    
+    DatasetOccurrenceDownloadUsage downloadDataset2 = new DatasetOccurrenceDownloadUsage();
+    downloadDataset2.setDownloadKey(occurrenceDownload.getKey());
+    downloadDataset2.setDatasetKey(testDataset2.getKey());
+    downloadDataset2.setNumberRecords(10000L);
+    downloadDataset2.setDatasetTitle(testDataset2.getTitle());
+    downloadDataset2.setDatasetDOI(new DOI("doi:10.1234/1ASCDU"));
+    downloadDataset2.setDatasetCitation(testDataset2.getCitation().getText());
+    
+    occurrenceDownloadService.create(occurrenceDownload);
+    datasetOccurrenceDownloadUsageService.bulkCreate(Arrays.asList(downloadDataset1,downloadDataset2));
+    assertEquals("List operation should return 1 record", 1,
+      datasetOccurrenceDownloadUsageService.listByDataset(testDataset1.getKey(), new PagingRequest(0, 3))
+        .getResults().size());
+    assertEquals("List operation should return 1 record", 1,
+        datasetOccurrenceDownloadUsageService.listByDataset(testDataset2.getKey(), new PagingRequest(0, 3))
+          .getResults().size());
+    Download occDownload2 = occurrenceDownloadService.get(occurrenceDownload.getKey());
+    assertEquals(occDownload2.getNumberDatasets(), 2);
   }
 
 }


### PR DESCRIPTION
List of changes:
1. Added new webservice endpoint: HTTP POST (occurrence/download/{downloadkey}/datasets}.
2. Removed webservice endpoint : DatasetOccurrenceDownloadUsageResource:create
3. Added and removed endpoints in registry-ws-client accordingly.
4. Added integration test to test new endpoint.
