### PR TITLE
Use data-provider citation for datasets in the OBIS network.

### DIFF
--- a/docs/citations.md
+++ b/docs/citations.md
@@ -1,7 +1,7 @@
 # How citations are generated
 
-In order to offer a consistent citations, all citations are auto-generated for all datasets.
- * Documentation available on the GBIF.org [FAQ](https://www.gbif.org/faq#citation)
+In order to offer a consistent citations, citations are auto-generated for most datasets.
+ * Documentation available on the GBIF.org [FAQ](https://www.gbif.org/faq?q=citation)
  * Based on discussion from [Issue #4](https://github.com/gbif/registry/issues/4).
  * Source Code: [CitationGenerator.java](https://github.com/gbif/registry/blob/master/registry-metadata/src/main/java/org/gbif/registry/metadata/CitationGenerator.java)
 


### PR DESCRIPTION
Resolves https://github.com/gbif/registry/issues/43

Further work is required: 
- [ ] Fix dataset metadata ingestion, so the `citation` column in the `dataset` table retains the publisher-provided citation.
- [ ] Re-sync metadata for the 2800 datasets that have a GBIF-generated citation (with "accessed … on 2017-05-31" or whatever old date) in this field
- [ ] Add a test case for this change
- [ ] Fix the TODO in this change
