### PR TITLE
#272 gridded datasets api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <gbif-common-mybatis.version>0.31</gbif-common-mybatis.version>
     <gbif-download-query-tools.version>1.36</gbif-download-query-tools.version>
     <gbif-postal-service.version>0.45</gbif-postal-service.version>
-    <gbif-api.version>0.132</gbif-api.version>
+    <gbif-api.version>0.133-SNAPSHOT</gbif-api.version>
     <gbif-directory.version>1.10</gbif-directory.version>
     <gbif-metrics.version>1.0</gbif-metrics.version>
     <gbif-parsers.version>0.36</gbif-parsers.version>

--- a/registry-integration-tests/src/test/java/org/gbif/registry/persistence/mapper/MockDatasetMapper.java
+++ b/registry-integration-tests/src/test/java/org/gbif/registry/persistence/mapper/MockDatasetMapper.java
@@ -437,4 +437,9 @@ public class MockDatasetMapper implements DatasetMapper {
   public List<Tag> listTags(@Param("targetEntityKey") UUID targetEntityKey) {
     return null;
   }
+
+  @Override
+  public String gridded(UUID datasetKey) {
+    return null;
+  }
 }

--- a/registry-integration-tests/src/test/java/org/gbif/registry/persistence/mapper/MockDatasetMapper.java
+++ b/registry-integration-tests/src/test/java/org/gbif/registry/persistence/mapper/MockDatasetMapper.java
@@ -24,6 +24,7 @@ import org.gbif.api.model.registry.Identifier;
 import org.gbif.api.model.registry.Installation;
 import org.gbif.api.model.registry.MachineTag;
 import org.gbif.api.model.registry.Tag;
+import org.gbif.api.model.registry.Grid;
 import org.gbif.api.vocabulary.ContactType;
 import org.gbif.api.vocabulary.Country;
 import org.gbif.api.vocabulary.DatasetType;
@@ -439,7 +440,7 @@ public class MockDatasetMapper implements DatasetMapper {
   }
 
   @Override
-  public String gridded(UUID datasetKey) {
+  public List<Grid> listGrids(UUID datasetKey) {
     return null;
   }
 }

--- a/registry-oaipmh/src/test/java/org/gbif/registry/oaipmh/MockDatasetMapper.java
+++ b/registry-oaipmh/src/test/java/org/gbif/registry/oaipmh/MockDatasetMapper.java
@@ -438,4 +438,9 @@ public class MockDatasetMapper implements DatasetMapper {
   public List<Tag> listTags(@Param("targetEntityKey") UUID targetEntityKey) {
     return null;
   }
+
+  @Override
+  public String gridded(UUID datasetKey) {
+    return null;
+  }
 }

--- a/registry-oaipmh/src/test/java/org/gbif/registry/oaipmh/MockDatasetMapper.java
+++ b/registry-oaipmh/src/test/java/org/gbif/registry/oaipmh/MockDatasetMapper.java
@@ -24,6 +24,7 @@ import org.gbif.api.model.registry.Identifier;
 import org.gbif.api.model.registry.Installation;
 import org.gbif.api.model.registry.MachineTag;
 import org.gbif.api.model.registry.Tag;
+import org.gbif.api.model.registry.Grid;
 import org.gbif.api.vocabulary.ContactType;
 import org.gbif.api.vocabulary.Country;
 import org.gbif.api.vocabulary.DatasetType;
@@ -440,7 +441,7 @@ public class MockDatasetMapper implements DatasetMapper {
   }
 
   @Override
-  public String gridded(UUID datasetKey) {
+  public List<Grid> listGrids(UUID datasetKey) {
     return null;
   }
 }

--- a/registry-persistence/src/main/java/org/gbif/registry/persistence/mapper/DatasetMapper.java
+++ b/registry-persistence/src/main/java/org/gbif/registry/persistence/mapper/DatasetMapper.java
@@ -141,4 +141,6 @@ public interface DatasetMapper extends BaseNetworkEntityMapper<Dataset> {
    * @return The list of distinct installations that serves at least one dataset.
    */
   List<Installation> listDistinctInstallations(@Nullable @Param("page") Pageable page);
+
+  String gridded(@Param("datasetKey") UUID datasetKey);
 }

--- a/registry-persistence/src/main/java/org/gbif/registry/persistence/mapper/DatasetMapper.java
+++ b/registry-persistence/src/main/java/org/gbif/registry/persistence/mapper/DatasetMapper.java
@@ -17,6 +17,7 @@ package org.gbif.registry.persistence.mapper;
 
 import org.gbif.api.model.common.paging.Pageable;
 import org.gbif.api.model.registry.Dataset;
+import org.gbif.api.model.registry.Grid;
 import org.gbif.api.model.registry.Installation;
 import org.gbif.api.vocabulary.Country;
 import org.gbif.api.vocabulary.DatasetType;
@@ -142,5 +143,5 @@ public interface DatasetMapper extends BaseNetworkEntityMapper<Dataset> {
    */
   List<Installation> listDistinctInstallations(@Nullable @Param("page") Pageable page);
 
-  String gridded(@Param("datasetKey") UUID datasetKey);
+  List<Grid> listGrids(@Param("datasetKey") UUID datasetKey);
 }

--- a/registry-persistence/src/main/resources/liquibase/087-dataset-gridded.xml
+++ b/registry-persistence/src/main/resources/liquibase/087-dataset-gridded.xml
@@ -9,11 +9,15 @@
           CREATE TABLE IF NOT exists dataset_gridded (
               "key" bigserial NOT NULL,
               dataset_key uuid NOT NULL,
-              grids json NULL,
-              CONSTRAINT dataset_gridded_pk PRIMARY KEY (key),
-              CONSTRAINT dataset_gridded_un UNIQUE (dataset_key),
-              CONSTRAINT dataset_gridded_fk FOREIGN KEY (dataset_key) REFERENCES dataset(key)
+              total_count int,
+              min_dist float,
+              min_dist_count int,
+              "percent" float,
+              max_percent float,
+              CONSTRAINT dataset_gridded_pk PRIMARY KEY (key)
           );
+
+          CREATE INDEX IF NOT EXISTS dataset_griddeds_dataset_key_idx ON dataset_gridded(dataset_key);
        ]]>
     </sql>
   </changeSet>

--- a/registry-persistence/src/main/resources/liquibase/087-dataset-gridded.xml
+++ b/registry-persistence/src/main/resources/liquibase/087-dataset-gridded.xml
@@ -1,0 +1,20 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+
+  <changeSet id="87" author="nvolik" runInTransaction="false">
+    <sql splitStatements="false" stripComments="false">
+      <![CDATA[
+          CREATE TABLE IF NOT exists dataset_gridded (
+              "key" bigserial NOT NULL,
+              dataset_key uuid NOT NULL,
+              grids json NULL,
+              CONSTRAINT dataset_gridded_pk PRIMARY KEY (key),
+              CONSTRAINT dataset_gridded_un UNIQUE (dataset_key),
+              CONSTRAINT dataset_gridded_fk FOREIGN KEY (dataset_key) REFERENCES dataset(key)
+          );
+       ]]>
+    </sql>
+  </changeSet>
+</databaseChangeLog>

--- a/registry-persistence/src/main/resources/liquibase/master.xml
+++ b/registry-persistence/src/main/resources/liquibase/master.xml
@@ -92,4 +92,5 @@
   <include file="liquibase/084-grscicoll-lookup-explicit-mappings-table.xml" />
   <include file="liquibase/085-grscicoll-triggers-updated.xml" />
   <include file="liquibase/086-grscicoll-replacedBy.xml" />
+  <include file="liquibase/087-dataset-gridded.xml" />
 </databaseChangeLog>

--- a/registry-persistence/src/main/resources/org/gbif/registry/persistence/mapper/DatasetMapper.xml
+++ b/registry-persistence/src/main/resources/org/gbif/registry/persistence/mapper/DatasetMapper.xml
@@ -677,4 +677,10 @@
     </if>
   </select>
 
+  <select id="gridded" resultType="String">
+    SELECT grids
+    FROM dataset_gridded
+    WHERE dataset_key = #{key,jdbcType=OTHER}
+  </select>
+
 </mapper>

--- a/registry-persistence/src/main/resources/org/gbif/registry/persistence/mapper/DatasetMapper.xml
+++ b/registry-persistence/src/main/resources/org/gbif/registry/persistence/mapper/DatasetMapper.xml
@@ -677,10 +677,16 @@
     </if>
   </select>
 
-  <select id="gridded" resultType="String">
-    SELECT grids
-    FROM dataset_gridded
-    WHERE dataset_key = #{datasetKey,jdbcType=OTHER}
+  <select id="listGrids" resultType="org.gbif.api.model.registry.Grid">
+    SELECT
+      dg.key,
+      dg.total_count,
+      dg.min_dist,
+      dg.min_dist_count,
+      dg.percent,
+      dg.max_percent
+    FROM dataset_gridded dg
+    WHERE dg.dataset_key = #{datasetKey,jdbcType=OTHER}
   </select>
 
 </mapper>

--- a/registry-persistence/src/main/resources/org/gbif/registry/persistence/mapper/DatasetMapper.xml
+++ b/registry-persistence/src/main/resources/org/gbif/registry/persistence/mapper/DatasetMapper.xml
@@ -680,7 +680,7 @@
   <select id="gridded" resultType="String">
     SELECT grids
     FROM dataset_gridded
-    WHERE dataset_key = #{key,jdbcType=OTHER}
+    WHERE dataset_key = #{datasetKey,jdbcType=OTHER}
   </select>
 
 </mapper>

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
@@ -33,6 +33,7 @@ import org.gbif.api.model.registry.Network;
 import org.gbif.api.model.registry.PostPersist;
 import org.gbif.api.model.registry.PrePersist;
 import org.gbif.api.model.registry.Tag;
+import org.gbif.api.model.registry.Grid;
 import org.gbif.api.model.registry.search.DatasetSearchParameter;
 import org.gbif.api.model.registry.search.DatasetSearchRequest;
 import org.gbif.api.model.registry.search.DatasetSearchResult;
@@ -733,8 +734,8 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset>
 
   @GetMapping("{key}/gridded")
   @Override
-  public String gridded(@PathVariable("key") UUID datasetKey) {
-    return datasetMapper.gridded(datasetKey);
+  public List<Grid> listGrids(@PathVariable("key") UUID datasetKey) {
+    return datasetMapper.listGrids(datasetKey);
   }
 
   @GetMapping("{key}/metadata")

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
@@ -731,6 +731,12 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset>
     return pagingResponse(page, datasetMapper.countSubdatasets(), datasetMapper.subdatasets(page));
   }
 
+  @GetMapping("{key}/gridded")
+  @Override
+  public String gridded(@PathVariable("key") UUID datasetKey) {
+    return datasetMapper.gridded(datasetKey);
+  }
+
   @GetMapping("{key}/metadata")
   @Override
   public List<Metadata> listMetadata(


### PR DESCRIPTION
API for [Gridded datasets project](https://github.com/gbif/gridded-datasets)

The table is populated by oozie workflow using occurrence hive table and can't be populated outside.

Dataset key doesn't have FK, because it uses dataset keys from occurrence table and it can be outdated