### PR TITLE
Work for #797 - fixes for ingestion GH issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,7 @@
     <!-- Plugin versions -->
     <spring-boot-maven-plugin.version>${spring-boot.version}</spring-boot-maven-plugin.version>
     <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+    <parquet.version>1.12.3</parquet.version>
   </properties>
 
   <dependencyManagement>
@@ -691,11 +692,41 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-mapreduce-client-core</artifactId>
+        <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.reload4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
 
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.parquet</groupId>
+        <artifactId>parquet-avro</artifactId>
+        <version>${parquet.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.parquet</groupId>
+        <artifactId>parquet-hadoop</artifactId>
+        <version>${parquet.version}</version>
       </dependency>
 
       <!-- CSV exports -->

--- a/registry-pipelines/pom.xml
+++ b/registry-pipelines/pom.xml
@@ -97,10 +97,42 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.servlet</groupId>
+          <artifactId>servlet-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.servlet.jsp</groupId>
+          <artifactId>jsp-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-runtime</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>tomcat</groupId>
+          <artifactId>jasper-compiler</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
+    </dependency>
+
+    <!-- Parquet (for reading parquet files with Avro GenericRecord) -->
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/registry-pipelines/src/main/java/org/gbif/registry/pipelines/issues/IssueCreator.java
+++ b/registry-pipelines/src/main/java/org/gbif/registry/pipelines/issues/IssueCreator.java
@@ -32,7 +32,6 @@ import org.gbif.ws.json.JacksonJsonObjectMapperProvider;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -48,7 +47,6 @@ import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
-// removed AvroFSInput import - reading Parquet instead of Avro
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.RemoteIterator;

--- a/registry-pipelines/src/main/java/org/gbif/registry/pipelines/issues/IssueCreator.java
+++ b/registry-pipelines/src/main/java/org/gbif/registry/pipelines/issues/IssueCreator.java
@@ -32,6 +32,7 @@ import org.gbif.ws.json.JacksonJsonObjectMapperProvider;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -42,13 +43,12 @@ import java.util.stream.Collectors;
 
 import jakarta.validation.constraints.NotNull;
 
-import org.apache.avro.file.DataFileReader;
-import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.DatumReader;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.AvroFSInput;
+// removed AvroFSInput import - reading Parquet instead of Avro
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.RemoteIterator;
@@ -86,6 +86,7 @@ public class IssueCreator {
   private static final String ATTEMPT_LABEL_TEMPLATE = "Attempt %s";
   private static final String PUBLISHER_LABEL_TEMPLATE = "pub: %s";
   private static final String INSTALLATION_LABEL_TEMPLATE = "inst: %s";
+  private static final String ENVIRONMENT_LABEL_TEMPLATE = "env: %s";
   private static final UnaryOperator<String> PORTAL_URL_NORMALIZER =
       url -> {
         if (url != null && url.endsWith("/")) {
@@ -164,8 +165,24 @@ public class IssueCreator {
         organizationMapper.getLightweight(dataset.getPublishingOrganizationKey());
     Installation installation = installationMapper.getLightweight(dataset.getInstallationKey());
 
-    List<String> newIds = readIdentifiersFromAvro(datasetKey, attempt);
-    List<String> oldIds = readIdentifiersFromES(datasetKey);
+    boolean errorLoadingNewIds = false;
+    boolean errorLoadingExistingIds = false;
+    List<String> newIds = new ArrayList<>();
+    List<String> oldIds = new ArrayList<>();
+
+    try {
+      newIds = readIdentifiersFromAvro(datasetKey, attempt);
+    } catch (Exception e) {
+      errorLoadingNewIds = true;
+      log.error("Error reading identifiers from avro dataset", e);
+    }
+
+    try {
+      oldIds = readIdentifiersFromES(datasetKey);
+    }  catch (Exception e) {
+      errorLoadingExistingIds = true;
+      log.error("Error reading identifiers from ES dataset", e);
+    }
 
     String body =
         buildIssueBody(
@@ -178,7 +195,9 @@ public class IssueCreator {
             organization,
             installation,
             newIds,
-            oldIds);
+            oldIds,
+            errorLoadingNewIds,
+            errorLoadingExistingIds);
     return Issue.builder()
         .title(String.format(IDS_VALIDATION_FAILED_TITLE, dataset.getTitle()))
         .body(body)
@@ -189,6 +208,7 @@ public class IssueCreator {
                 String.format(COUNTRY_LABEL_TEMPLATE, organization.getCountry()),
                 String.format(PUBLISHER_LABEL_TEMPLATE, organization.getKey()),
                 String.format(INSTALLATION_LABEL_TEMPLATE, installation.getKey()),
+                String.format(ENVIRONMENT_LABEL_TEMPLATE, issuesConfig.environment),
                 getCurrentTimestamp()))
         .build();
   }
@@ -204,7 +224,10 @@ public class IssueCreator {
       Organization organization,
       Installation installation,
       List<String> newIds,
-      List<String> oldIds) {
+      List<String> oldIds,
+      boolean errorLoadingNewIds,
+      boolean errorLoadingExistingIds
+      ) {
 
     long occCount =
         cubeWsClient.get(new LinkedMultiValueMap<>(Collections.singletonMap("datasetKey", Collections.singletonList(datasetKey.toString()))));
@@ -259,6 +282,13 @@ public class IssueCreator {
                 datasetKey.toString()))
         .append(".");
 
+    if (errorLoadingNewIds) {
+      body.append(NEW_LINE).append(NEW_LINE).append("**WARNING - Error loading new identifiers from Parquet files.**");
+    }
+    if (errorLoadingExistingIds) {
+      body.append(NEW_LINE).append(NEW_LINE).append("**WARNING - Error loading new identifiers from Elastic.**");
+    }
+
     return body.toString();
   }
 
@@ -270,8 +300,23 @@ public class IssueCreator {
       throw new IllegalArgumentException(DATASET_NOT_FOUND_FOR_KEY + datasetKey);
     }
 
-    List<String> newIds = readIdentifiersFromAvro(datasetKey, attempt);
-    List<String> oldIds = readIdentifiersFromES(datasetKey);
+    boolean errorLoadingNewIds = false;
+    boolean errorLoadingExistingIds = false;
+    List<String> newIds = new ArrayList<>();
+    List<String> oldIds = new ArrayList<>();
+
+    try {
+      newIds = readIdentifiersFromAvro(datasetKey, attempt);
+    } catch (Exception e) {
+      errorLoadingNewIds = true;
+      log.error("Error reading identifiers from Avro dataset", e);
+    }
+    try {
+      oldIds = readIdentifiersFromES(datasetKey);
+    }  catch (Exception e) {
+      errorLoadingExistingIds = true;
+      log.error("Error reading identifiers from ES dataset", e);
+    }
 
     Organization organization =
         organizationMapper.getLightweight(dataset.getPublishingOrganizationKey());
@@ -288,7 +333,9 @@ public class IssueCreator {
             organization,
             installation,
             newIds,
-            oldIds);
+            oldIds,
+            errorLoadingNewIds,
+            errorLoadingExistingIds);
 
     return GithubApiClient.IssueComment.builder().body(body).build();
   }
@@ -381,49 +428,68 @@ public class IssueCreator {
 
   @SneakyThrows
   private List<String> readIdentifiersFromAvro(UUID datasetKey, int attempt) {
-    FileSystem fs =
-        FileSystem.get(
-            URI.create(issuesConfig.hdfsPrefix), getHdfsConfiguration(issuesConfig.hdfsSiteConfig));
-
-    org.apache.hadoop.fs.Path identifiersPath =
-        new org.apache.hadoop.fs.Path(
-            issuesConfig.hdfsPrefix
-                + "/data/ingest/"
-                + datasetKey
-                + "/"
-                + attempt
-                + "/occurrence/identifier");
 
     List<String> identifiers = new ArrayList<>();
-    try {
-      RemoteIterator<LocatedFileStatus> iterator = fs.listFiles(identifiersPath, false);
-      while (iterator.hasNext() && identifiers.size() < NUM_SAMPLE_IDS) {
-        LocatedFileStatus fileStatus = iterator.next();
-        if (fileStatus.isFile()) {
+    FileSystem fs =
+      FileSystem.get(
+        URI.create(issuesConfig.hdfsPrefix), getHdfsConfiguration(issuesConfig.hdfsSiteConfig));
 
-          DatumReader<GenericRecord> datumReader = new GenericDatumReader<>();
-          try (DataFileReader<GenericRecord> dataFileReader =
-              new DataFileReader<>(
-                  new AvroFSInput(
-                      fs.open(fileStatus.getPath()),
-                      fs.getContentSummary(fileStatus.getPath()).getLength()),
-                  datumReader)) {
+    org.apache.hadoop.fs.Path absentIdentifiersPath =
+      new org.apache.hadoop.fs.Path(
+        issuesConfig.hdfsPrefix
+          + issuesConfig.ingestDirectoryBasePath
+          + "/"
+          + datasetKey
+          + "/"
+          + attempt
+          + "/identifiers_absent");
 
-            GenericRecord genericRecord = null;
-            while (dataFileReader.hasNext() && identifiers.size() < NUM_SAMPLE_IDS) {
-              genericRecord = dataFileReader.next(genericRecord);
-              if (genericRecord.get("id") != null) {
-                identifiers.add(genericRecord.get("id").toString());
+    org.apache.hadoop.fs.Path invalidIdentifiersPath =
+      new org.apache.hadoop.fs.Path(
+        issuesConfig.hdfsPrefix
+          + issuesConfig.ingestDirectoryBasePath
+          + "/"
+          + datasetKey
+          + "/"
+          + attempt
+          + "/identifiers_invalid");
+
+    org.apache.hadoop.fs.Path validIdentifiersPath =
+      new org.apache.hadoop.fs.Path(
+        issuesConfig.hdfsPrefix
+          + issuesConfig.ingestDirectoryBasePath
+          + "/"
+          + datasetKey
+          + "/"
+          + attempt
+          + "/identifiers_valid");
+
+    for (org.apache.hadoop.fs.Path identifiersPath :
+      List.of(absentIdentifiersPath, invalidIdentifiersPath, validIdentifiersPath)) {
+      try {
+        RemoteIterator<LocatedFileStatus> iterator = fs.listFiles(identifiersPath, false);
+        while (iterator.hasNext() && identifiers.size() < NUM_SAMPLE_IDS) {
+          LocatedFileStatus fileStatus = iterator.next();
+          if (fileStatus.isFile() && fileStatus.getPath().getName().endsWith(".parquet")) {
+            // Use AvroParquetReader to read parquet files containing Avro GenericRecords
+            org.apache.hadoop.fs.Path parquetPath = fileStatus.getPath();
+            try (ParquetReader<GenericRecord> reader =
+                   AvroParquetReader.<GenericRecord>builder(parquetPath).withConf(fs.getConf()).build()) {
+              GenericRecord record;
+              while ((record = reader.read()) != null && identifiers.size() < NUM_SAMPLE_IDS) {
+                if (record.get("id") != null) {
+                  identifiers.add(record.get("id").toString());
+                }
               }
             }
           }
         }
+      } catch (FileNotFoundException ex) {
+        throw new IllegalArgumentException(
+          "Identifier parquet files not found for dataset " + datasetKey + " and attempt " + attempt
+            + ". Error " + ex.getMessage(), ex);
       }
-    } catch (FileNotFoundException ex) {
-      throw new IllegalArgumentException(
-          "Identifier avro files not found for dataset " + datasetKey + " and attempt " + attempt);
     }
-
     return identifiers;
   }
 

--- a/registry-pipelines/src/main/java/org/gbif/registry/pipelines/issues/IssuesConfig.java
+++ b/registry-pipelines/src/main/java/org/gbif/registry/pipelines/issues/IssuesConfig.java
@@ -31,4 +31,6 @@ public class IssuesConfig {
   @NotEmpty private String githubPassword;
   @NotEmpty public String hdfsSiteConfig;
   @NotEmpty public String hdfsPrefix = "hdfs://gbif-hdfs";
+  @NotEmpty public String ingestDirectoryBasePath = "/data/ingest";
+  @NotEmpty public String environment = "";
 }


### PR DESCRIPTION
Changes to read parquet files
Also changed to be tolerant of errors in reading parquet files and ES to retrieve old and new IDS, always logging the GH issue but including a warning if unsuccessful in reading parquet or ES.