### PR TITLE
Speed up dataset endpoint by using a simple query for network constituents

### DIFF
--- a/registry-persistence/src/main/java/org/gbif/registry/persistence/mapper/NetworkMapper.java
+++ b/registry-persistence/src/main/java/org/gbif/registry/persistence/mapper/NetworkMapper.java
@@ -49,4 +49,9 @@ public interface NetworkMapper extends BaseNetworkEntityMapper<Network> {
    * @return The list of networks, with only their key and title populated.
    */
   List<IptNetworkBriefResponse> listNetworksBrief();
+
+  /**
+   * @return The datasets (key only) within a network.
+   */
+  List<UUID> listConstituentsBrief(@Param("networkKey") UUID networkKey);
 }

--- a/registry-persistence/src/main/resources/org/gbif/registry/persistence/mapper/NetworkMapper.xml
+++ b/registry-persistence/src/main/resources/org/gbif/registry/persistence/mapper/NetworkMapper.xml
@@ -426,4 +426,16 @@
     )
     ORDER BY LOWER(n.title)
   </select>
+
+  <!-- All not-deleted datasets in a network. -->
+  <select id="listConstituentsBrief" resultType="java.util.UUID">
+    SELECT d.key
+    FROM network n
+    INNER JOIN dataset_network dn ON n.key = dn.network_key
+    INNER JOIN dataset d ON dn.dataset_key = d.key AND d.deleted IS NULL
+    WHERE
+      n.deleted IS NULL AND
+      network_key = #{networkKey,jdbcType=OTHER}
+    ORDER BY d.key
+  </select>
 </mapper>

--- a/registry-service/src/main/java/org/gbif/registry/service/RegistryDatasetServiceImpl.java
+++ b/registry-service/src/main/java/org/gbif/registry/service/RegistryDatasetServiceImpl.java
@@ -30,6 +30,7 @@ import org.gbif.registry.doi.util.RegistryDoiUtils;
 import org.gbif.registry.domain.ws.DerivedDatasetUsage;
 import org.gbif.registry.persistence.mapper.DatasetMapper;
 import org.gbif.registry.persistence.mapper.MetadataMapper;
+import org.gbif.registry.persistence.mapper.NetworkMapper;
 import org.gbif.registry.persistence.mapper.OrganizationMapper;
 import org.gbif.registry.persistence.mapper.handler.ByteArrayWrapper;
 import org.gbif.registry.persistence.mapper.params.DatasetListParams;
@@ -83,6 +84,7 @@ public class RegistryDatasetServiceImpl implements RegistryDatasetService {
 
   public RegistryDatasetServiceImpl(
       MetadataMapper metadataMapper,
+      NetworkMapper networkMapper,
       OrganizationMapper organizationMapper,
       DatasetMapper datasetMapper) {
     this.metadataMapper = metadataMapper;
@@ -104,11 +106,7 @@ public class RegistryDatasetServiceImpl implements RegistryDatasetService {
                 new CacheLoader<UUID, Set<UUID>>() {
                   @Override
                   public Set<UUID> load(UUID key) {
-                    return datasetMapper
-                        .list(DatasetListParams.builder().networkKey(key).build())
-                        .stream()
-                        .map(Dataset::getKey)
-                        .collect(Collectors.toSet());
+                    return new HashSet<>(networkMapper.listConstituentsBrief(key));
                   }
                 });
   }


### PR DESCRIPTION
This avoids reading ~3300 full dataset records in, just to see what datasets are in the OBIS network.

Closes #796.