### PR TITLE
Fix/issue 801 async calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.gbif.registry</groupId>
   <artifactId>registry-parent</artifactId>
-  <version>4.2.20-SNAPSHOT</version>
+  <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   <name>GBIF Registry Parent</name>
   <description>GBIF Registry project</description>
 

--- a/registry-cli/pom.xml
+++ b/registry-cli/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif.registry</groupId>
     <artifactId>registry-parent</artifactId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
 
   <artifactId>registry-cli</artifactId>

--- a/registry-cli/src/main/java/org/gbif/registry/cli/common/stubs/SearchServiceStub.java
+++ b/registry-cli/src/main/java/org/gbif/registry/cli/common/stubs/SearchServiceStub.java
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * Stub class used to simplify binding, e.g. when this class must be bound but isn't actually used.
  */
 @Qualifier("datasetSearchServiceEs")
-public class SearchServiceStub implements DatasetSearchService {
+public class SearchServiceStub implements DatasetSearchService, org.gbif.registry.search.dataset.service.AsyncDatasetSearchService {
 
   @Override
   public SearchResponse<DatasetSearchResult, DatasetSearchParameter> search(
@@ -40,5 +40,17 @@ public class SearchServiceStub implements DatasetSearchService {
   @Override
   public List<DatasetSuggestResult> suggest(DatasetSuggestRequest datasetSuggestRequest) {
     return null;
+  }
+
+  @Override
+  public java.util.concurrent.CompletableFuture<org.gbif.api.model.common.search.SearchResponse<DatasetSearchResult, DatasetSearchParameter>> searchAsync(
+      DatasetSearchRequest datasetSearchRequest) {
+    return java.util.concurrent.CompletableFuture.completedFuture(search(datasetSearchRequest));
+  }
+
+  @Override
+  public java.util.concurrent.CompletableFuture<java.util.List<DatasetSuggestResult>> suggestAsync(
+      DatasetSuggestRequest datasetSuggestRequest) {
+    return java.util.concurrent.CompletableFuture.completedFuture(suggest(datasetSuggestRequest));
   }
 }

--- a/registry-directory/pom.xml
+++ b/registry-directory/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-doi/pom.xml
+++ b/registry-doi/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-domain/pom.xml
+++ b/registry-domain/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-events/pom.xml
+++ b/registry-events/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-examples/pom.xml
+++ b/registry-examples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-identity/pom.xml
+++ b/registry-identity/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-integration-tests/pom.xml
+++ b/registry-integration-tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-integration-tests/src/test/java/org/gbif/registry/search/DatasetSearchServiceStub.java
+++ b/registry-integration-tests/src/test/java/org/gbif/registry/search/DatasetSearchServiceStub.java
@@ -24,7 +24,7 @@ import org.gbif.api.service.registry.DatasetSearchService;
 import java.util.Collections;
 import java.util.List;
 
-public class DatasetSearchServiceStub implements DatasetSearchService {
+public class DatasetSearchServiceStub implements DatasetSearchService, org.gbif.registry.search.dataset.service.AsyncDatasetSearchService {
 
   @Override
   public SearchResponse<DatasetSearchResult, DatasetSearchParameter> search(
@@ -38,5 +38,17 @@ public class DatasetSearchServiceStub implements DatasetSearchService {
   @Override
   public List<DatasetSuggestResult> suggest(DatasetSuggestRequest datasetSuggestRequest) {
     return Collections.emptyList();
+  }
+
+  @Override
+  public java.util.concurrent.CompletableFuture<SearchResponse<DatasetSearchResult, DatasetSearchParameter>> searchAsync(
+      DatasetSearchRequest datasetSearchRequest) {
+    return java.util.concurrent.CompletableFuture.completedFuture(search(datasetSearchRequest));
+  }
+
+  @Override
+  public java.util.concurrent.CompletableFuture<java.util.List<DatasetSuggestResult>> suggestAsync(
+      DatasetSuggestRequest datasetSuggestRequest) {
+    return java.util.concurrent.CompletableFuture.completedFuture(suggest(datasetSuggestRequest));
   }
 }

--- a/registry-integration-tests/src/test/java/org/gbif/registry/ws/it/DatasetSearchAsyncIT.java
+++ b/registry-integration-tests/src/test/java/org/gbif/registry/ws/it/DatasetSearchAsyncIT.java
@@ -1,5 +1,6 @@
 package org.gbif.registry.ws.it;
 
+import org.gbif.registry.search.dataset.service.AsyncDatasetSearchService;
 import org.gbif.registry.search.test.ElasticsearchTestContainerConfiguration;
 import org.gbif.ws.client.filter.SimplePrincipalProvider;
 import org.gbif.api.model.registry.search.DatasetSuggestRequest;
@@ -18,12 +19,14 @@ public class DatasetSearchAsyncIT extends BaseItTest {
 
   @Autowired
   @Qualifier("datasetSearchServiceEs")
-  private org.gbif.registry.search.dataset.service.AsyncDatasetSearchService asyncSearchService;
+  private AsyncDatasetSearchService asyncSearchService;
 
+  @Autowired
   public DatasetSearchAsyncIT(SimplePrincipalProvider simplePrincipalProvider,
-      ElasticsearchTestContainerConfiguration elasticsearchTestContainer) {
+    ElasticsearchTestContainerConfiguration elasticsearchTestContainer) {
     super(simplePrincipalProvider, elasticsearchTestContainer);
   }
+
 
   @Test
   public void testSuggestAsyncReturns() throws Exception {

--- a/registry-integration-tests/src/test/java/org/gbif/registry/ws/it/DatasetSearchAsyncIT.java
+++ b/registry-integration-tests/src/test/java/org/gbif/registry/ws/it/DatasetSearchAsyncIT.java
@@ -1,0 +1,38 @@
+package org.gbif.registry.ws.it;
+
+import org.gbif.registry.search.test.ElasticsearchTestContainerConfiguration;
+import org.gbif.ws.client.filter.SimplePrincipalProvider;
+import org.gbif.api.model.registry.search.DatasetSuggestRequest;
+import org.gbif.api.model.registry.search.DatasetSuggestResult;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/** Simple integration test verifying async suggest wiring. */
+public class DatasetSearchAsyncIT extends BaseItTest {
+
+  @Autowired
+  @Qualifier("datasetSearchServiceEs")
+  private org.gbif.registry.search.dataset.service.AsyncDatasetSearchService asyncSearchService;
+
+  public DatasetSearchAsyncIT(SimplePrincipalProvider simplePrincipalProvider,
+      ElasticsearchTestContainerConfiguration elasticsearchTestContainer) {
+    super(simplePrincipalProvider, elasticsearchTestContainer);
+  }
+
+  @Test
+  public void testSuggestAsyncReturns() throws Exception {
+    DatasetSuggestRequest req = new DatasetSuggestRequest();
+    req.setQ("test");
+    java.util.concurrent.CompletableFuture<List<DatasetSuggestResult>> fut = asyncSearchService.suggestAsync(req);
+    assertNotNull(fut);
+    List<DatasetSuggestResult> results = fut.get();
+    assertNotNull(results);
+  }
+}
+

--- a/registry-integration-tests/src/test/java/org/gbif/registry/ws/it/DatasetSearchAsyncIT.java
+++ b/registry-integration-tests/src/test/java/org/gbif/registry/ws/it/DatasetSearchAsyncIT.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gbif.registry.ws.it;
 
 import org.gbif.registry.search.dataset.service.AsyncDatasetSearchService;

--- a/registry-mail/pom.xml
+++ b/registry-mail/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-messaging/pom.xml
+++ b/registry-messaging/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-oaipmh/pom.xml
+++ b/registry-oaipmh/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-persistence/pom.xml
+++ b/registry-persistence/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-pipelines/pom.xml
+++ b/registry-pipelines/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-search/pom.xml
+++ b/registry-search/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-search/src/main/java/org/gbif/registry/search/dataset/service/AsyncDatasetSearchService.java
+++ b/registry-search/src/main/java/org/gbif/registry/search/dataset/service/AsyncDatasetSearchService.java
@@ -1,0 +1,21 @@
+package org.gbif.registry.search.dataset.service;
+
+import org.gbif.api.model.common.search.SearchResponse;
+import org.gbif.api.model.registry.search.DatasetSearchParameter;
+import org.gbif.api.model.registry.search.DatasetSearchRequest;
+import org.gbif.api.model.registry.search.DatasetSearchResult;
+import org.gbif.api.model.registry.search.DatasetSuggestRequest;
+import org.gbif.api.model.registry.search.DatasetSuggestResult;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/** Async search interface for dataset search backed by Elasticsearch. */
+public interface AsyncDatasetSearchService {
+
+  CompletableFuture<SearchResponse<DatasetSearchResult, DatasetSearchParameter>> searchAsync(
+      DatasetSearchRequest datasetSearchRequest);
+
+  CompletableFuture<List<DatasetSuggestResult>> suggestAsync(DatasetSuggestRequest datasetSuggestRequest);
+}
+

--- a/registry-search/src/main/java/org/gbif/registry/search/dataset/service/DatasetSearchServiceEs.java
+++ b/registry-search/src/main/java/org/gbif/registry/search/dataset/service/DatasetSearchServiceEs.java
@@ -26,10 +26,11 @@ import org.gbif.registry.search.dataset.DatasetEsFieldMapper;
 import org.gbif.registry.search.dataset.DatasetEsResponseParser;
 import org.gbif.registry.search.dataset.common.EsSearchRequestBuilder;
 
-import java.io.IOException;
 import java.util.List;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import java.util.concurrent.CompletableFuture;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -41,7 +42,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Service
 @Qualifier("datasetSearchServiceEs")
-public class DatasetSearchServiceEs implements DatasetSearchService {
+
+public class DatasetSearchServiceEs implements DatasetSearchService, AsyncDatasetSearchService {
 
   private static final int DEFAULT_SUGGEST_LIMIT = 10;
   private static final int MAX_SUGGEST_LIMIT = 100;
@@ -53,12 +55,17 @@ public class DatasetSearchServiceEs implements DatasetSearchService {
   private final EsSearchRequestBuilder<DatasetSearchParameter> esSearchRequestBuilder =
       new EsSearchRequestBuilder<>(new DatasetEsFieldMapper());
 
+  private final ElasticsearchAsyncClient elasticsearchAsyncClient;
+
   @Autowired
   public DatasetSearchServiceEs(
       @Value("${elasticsearch.registry.index}") String index,
-      ElasticsearchClient elasticsearchClient) {
+      ElasticsearchClient elasticsearchClient,
+      // async client is optional in some configurations - Spring will inject if available
+      ElasticsearchAsyncClient elasticsearchAsyncClient) {
     this.index = index;
     this.elasticsearchClient = elasticsearchClient;
+    this.elasticsearchAsyncClient = elasticsearchAsyncClient;
   }
 
   @Override
@@ -72,8 +79,119 @@ public class DatasetSearchServiceEs implements DatasetSearchService {
           elasticsearchClient.search(searchRequest, ObjectNode.class);
       return esResponseParser.buildSearchResponse(response, datasetSearchRequest);
     } catch (Exception ex) {
-      log.error("Error while searching datasets", ex);
+      // If the thread was interrupted while waiting on the low-level future, restore the
+      // interrupt flag and provide a clearer error.
+      Throwable cause = ex instanceof RuntimeException ? ex.getCause() : ex;
+      if (cause instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+        log.warn("Search was interrupted", ex);
+        throw new RuntimeException("Search was interrupted", ex);
+      }
+
+      log.error("Error while searching datasets: {} - {}", ex.getClass().getName(), ex.getMessage());
+      Throwable cause2 = ex.getCause();
+      int depth2 = 0;
+      while (cause2 != null && depth2 < 10) {
+        log.error("cause[{}]: {} - {}", depth2, cause2.getClass().getName(), cause2.getMessage());
+        cause2 = cause2.getCause();
+        depth2++;
+      }
       throw new RuntimeException(ex);
+    }
+  }
+
+  /**
+   * Asynchronous version of search that returns a CompletableFuture. Useful to avoid blocking
+   * request threads and to surface more detailed errors upstream.
+   */
+  public CompletableFuture<SearchResponse<DatasetSearchResult, DatasetSearchParameter>> searchAsync(
+      DatasetSearchRequest datasetSearchRequest) {
+    if (elasticsearchAsyncClient == null) {
+      return CompletableFuture.failedFuture(new IllegalStateException("Elasticsearch async client not configured"));
+    }
+
+    try {
+      SearchRequest searchRequest =
+          esSearchRequestBuilder.buildSearchRequest(datasetSearchRequest, true, index);
+      log.debug("Async search request: {}", searchRequest);
+
+      CompletableFuture<co.elastic.clients.elasticsearch.core.SearchResponse<ObjectNode>> esFuture =
+          elasticsearchAsyncClient.search(searchRequest, ObjectNode.class);
+
+      return esFuture.thenApply(response -> esResponseParser.buildSearchResponse(response, datasetSearchRequest))
+          .exceptionally(ex -> {
+            // If interrupted, restore flag
+            Throwable cause = ex instanceof RuntimeException ? ex.getCause() : ex;
+            if (cause instanceof InterruptedException) {
+              Thread.currentThread().interrupt();
+            }
+            log.error("Async search failed: {} - {}", ex.getClass().getName(), ex.getMessage());
+            Throwable nested = ex.getCause();
+            int d = 0;
+            while (nested != null && d < 10) {
+              log.error("cause[{}]: {} - {}", d, nested.getClass().getName(), nested.getMessage());
+              nested = nested.getCause();
+              d++;
+            }
+            throw new RuntimeException("Async search failed", ex);
+          });
+    } catch (Exception ex) {
+      return CompletableFuture.failedFuture(ex);
+    }
+  }
+
+  /**
+   * Asynchronous version of suggest that returns a CompletableFuture of the suggestion results.
+   */
+  public CompletableFuture<java.util.List<DatasetSuggestResult>> suggestAsync(
+      DatasetSuggestRequest datasetSuggestRequest) {
+    if (elasticsearchAsyncClient == null) {
+      return CompletableFuture.failedFuture(new IllegalStateException("Elasticsearch async client not configured"));
+    }
+
+    try {
+      int limit = datasetSuggestRequest.getLimit();
+      if (limit <= 0) {
+        limit = DEFAULT_SUGGEST_LIMIT;
+      } else if (limit > MAX_SUGGEST_LIMIT) {
+        limit = MAX_SUGGEST_LIMIT;
+      }
+
+      // Create a copy of the request with the validated limit
+      DatasetSuggestRequest modifiedRequest = new DatasetSuggestRequest();
+      modifiedRequest.setQ(datasetSuggestRequest.getQ());
+      modifiedRequest.setLimit(limit);
+      modifiedRequest.setOffset(datasetSuggestRequest.getOffset());
+      modifiedRequest.setParameters(datasetSuggestRequest.getParameters());
+
+      SearchRequest searchRequest =
+          esSearchRequestBuilder.buildAutocompleteQuery(modifiedRequest, DatasetSearchParameter.DATASET_TITLE, index);
+      log.debug("Async suggest request: {}", searchRequest);
+
+      CompletableFuture<co.elastic.clients.elasticsearch.core.SearchResponse<ObjectNode>> esFuture =
+          elasticsearchAsyncClient.search(searchRequest, ObjectNode.class);
+
+      return esFuture.thenApply(response -> {
+        org.gbif.api.model.common.search.SearchResponse<DatasetSuggestResult, org.gbif.api.model.registry.search.DatasetSearchParameter> autocompleteResponse =
+            esResponseParser.buildSearchAutocompleteResponse(response, modifiedRequest);
+        return autocompleteResponse.getResults();
+      }).exceptionally(ex -> {
+        Throwable cause = ex instanceof RuntimeException ? ex.getCause() : ex;
+        if (cause instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        log.error("Async suggest failed: {} - {}", ex.getClass().getName(), ex.getMessage());
+        Throwable nested = ex.getCause();
+        int d = 0;
+        while (nested != null && d < 10) {
+          log.error("cause[{}]: {} - {}", d, nested.getClass().getName(), nested.getMessage());
+          nested = nested.getCause();
+          d++;
+        }
+        throw new RuntimeException("Async suggest failed", ex);
+      });
+    } catch (Exception ex) {
+      return CompletableFuture.failedFuture(ex);
     }
   }
 

--- a/registry-search/src/main/java/org/gbif/registry/search/dataset/service/DatasetSearchServiceEs.java
+++ b/registry-search/src/main/java/org/gbif/registry/search/dataset/service/DatasetSearchServiceEs.java
@@ -35,6 +35,7 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import lombok.extern.slf4j.Slf4j;
@@ -81,21 +82,7 @@ public class DatasetSearchServiceEs implements DatasetSearchService, AsyncDatase
     } catch (Exception ex) {
       // If the thread was interrupted while waiting on the low-level future, restore the
       // interrupt flag and provide a clearer error.
-      Throwable cause = ex instanceof RuntimeException ? ex.getCause() : ex;
-      if (cause instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-        log.warn("Search was interrupted", ex);
-        throw new RuntimeException("Search was interrupted", ex);
-      }
-
-      log.error("Error while searching datasets: {} - {}", ex.getClass().getName(), ex.getMessage());
-      Throwable cause2 = ex.getCause();
-      int depth2 = 0;
-      while (cause2 != null && depth2 < 10) {
-        log.error("cause[{}]: {} - {}", depth2, cause2.getClass().getName(), cause2.getMessage());
-        cause2 = cause2.getCause();
-        depth2++;
-      }
+      this.handleInterruptedException(ex);
       throw new RuntimeException(ex);
     }
   }
@@ -104,6 +91,7 @@ public class DatasetSearchServiceEs implements DatasetSearchService, AsyncDatase
    * Asynchronous version of search that returns a CompletableFuture. Useful to avoid blocking
    * request threads and to surface more detailed errors upstream.
    */
+  @Async("boundedTaskExecutor")
   public CompletableFuture<SearchResponse<DatasetSearchResult, DatasetSearchParameter>> searchAsync(
       DatasetSearchRequest datasetSearchRequest) {
     if (elasticsearchAsyncClient == null) {
@@ -119,22 +107,10 @@ public class DatasetSearchServiceEs implements DatasetSearchService, AsyncDatase
           elasticsearchAsyncClient.search(searchRequest, ObjectNode.class);
 
       return esFuture.thenApply(response -> esResponseParser.buildSearchResponse(response, datasetSearchRequest))
-          .exceptionally(ex -> {
-            // If interrupted, restore flag
-            Throwable cause = ex instanceof RuntimeException ? ex.getCause() : ex;
-            if (cause instanceof InterruptedException) {
-              Thread.currentThread().interrupt();
-            }
-            log.error("Async search failed: {} - {}", ex.getClass().getName(), ex.getMessage());
-            Throwable nested = ex.getCause();
-            int d = 0;
-            while (nested != null && d < 10) {
-              log.error("cause[{}]: {} - {}", d, nested.getClass().getName(), nested.getMessage());
-              nested = nested.getCause();
-              d++;
-            }
-            throw new RuntimeException("Async search failed", ex);
-          });
+        .exceptionally(ex -> {
+          this.handleInterruptedException(ex);
+          throw new RuntimeException("Async suggest failed", ex);
+        });
     } catch (Exception ex) {
       return CompletableFuture.failedFuture(ex);
     }
@@ -143,6 +119,7 @@ public class DatasetSearchServiceEs implements DatasetSearchService, AsyncDatase
   /**
    * Asynchronous version of suggest that returns a CompletableFuture of the suggestion results.
    */
+  @Async("boundedTaskExecutor")
   public CompletableFuture<java.util.List<DatasetSuggestResult>> suggestAsync(
       DatasetSuggestRequest datasetSuggestRequest) {
     if (elasticsearchAsyncClient == null) {
@@ -176,22 +153,26 @@ public class DatasetSearchServiceEs implements DatasetSearchService, AsyncDatase
             esResponseParser.buildSearchAutocompleteResponse(response, modifiedRequest);
         return autocompleteResponse.getResults();
       }).exceptionally(ex -> {
-        Throwable cause = ex instanceof RuntimeException ? ex.getCause() : ex;
-        if (cause instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
-        }
-        log.error("Async suggest failed: {} - {}", ex.getClass().getName(), ex.getMessage());
-        Throwable nested = ex.getCause();
-        int d = 0;
-        while (nested != null && d < 10) {
-          log.error("cause[{}]: {} - {}", d, nested.getClass().getName(), nested.getMessage());
-          nested = nested.getCause();
-          d++;
-        }
+        this.handleInterruptedException(ex);
         throw new RuntimeException("Async suggest failed", ex);
       });
     } catch (Exception ex) {
       return CompletableFuture.failedFuture(ex);
+    }
+  }
+
+  private void handleInterruptedException(Throwable ex) {
+    Throwable cause = ex instanceof RuntimeException ? ex.getCause() : ex;
+    if (cause instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
+    }
+    log.error("Async suggest failed: {} - {}", ex.getClass().getName(), ex.getMessage());
+    Throwable nested = ex.getCause();
+    int d = 0;
+    while (nested != null && d < 10) {
+      log.error("cause[{}]: {} - {}", d, nested.getClass().getName(), nested.getMessage());
+      nested = nested.getCause();
+      d++;
     }
   }
 

--- a/registry-security/pom.xml
+++ b/registry-security/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-service/pom.xml
+++ b/registry-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>registry-parent</artifactId>
         <groupId>org.gbif.registry</groupId>
-        <version>4.2.20-SNAPSHOT</version>
+        <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/registry-surety/pom.xml
+++ b/registry-surety/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-ws-client/pom.xml
+++ b/registry-ws-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>registry-parent</artifactId>
     <groupId>org.gbif.registry</groupId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/registry-ws/ASYNC_EXECUTOR_README.md
+++ b/registry-ws/ASYNC_EXECUTOR_README.md
@@ -1,0 +1,114 @@
+Async Executor and Metrics (Prometheus)
+=====================================
+
+This document explains the bounded async executor introduced in `AsyncConfig`, the configuration properties you can tune, the metrics exposed (Micrometer) and how to scrape them with Prometheus. It also documents the bean name/qualifier and suggested operational behavior.
+
+Files and bean
+--------------
+- Bean created in: `org/gbif/registry/ws/config/AsyncConfig` (qualifier: `@Qualifier("boundedTaskExecutor")`).
+- Bean type: Spring `ThreadPoolTaskExecutor` (returned as `Executor`).
+- Profile: the existing `AsyncConfig` is annotated with `@Profile("!test")` in the project; the bean will not be created when the `test` profile is active.
+
+Configuration properties
+------------------------
+The executor can be tuned via the following configuration keys (defaults shown):
+
+```yaml
+# Tune the bounded task executor
+registry:
+  async:
+    corePoolSize: 20
+    maxPoolSize: 100
+    queueCapacity: 1000
+```
+
+If you use Spring Boot, these configuration keys can also be set as environment variables by converting the property path to uppercase with dots replaced by underscores, e.g. `REGISTRY_ASYNC_COREPOOLSIZE`.
+
+Bean usage
+----------
+- Qualifier name: `boundedTaskExecutor` (inject with `@Qualifier("boundedTaskExecutor")`).
+- The codebase uses the bean as optional injection in controllers/resources; if it is not present the code falls back to `CompletableFuture.supplyAsync(...)` without an explicit executor.
+- The bean should be present in production profiles to ensure controlled concurrency for blocking workloads.
+
+Metrics exposed (Micrometer -> Prometheus)
+-----------------------------------------
+The executor is instrumented with Micrometer gauges and the async exception handler is instrumented with counters. If you already export to Prometheus, these metrics will appear in your scrape target.
+
+Exposed metric names and labels (as registered by the code):
+
+1) Executor gauges (registered on the underlying `ThreadPoolExecutor`):
+- `registry.async.executor.active` - current active thread count (gauge)
+- `registry.async.executor.poolSize` - current pool size (gauge)
+- `registry.async.executor.queueSize` - current queue size (gauge)
+
+These are simple numeric gauges and are useful to detect saturation: growing `queueSize` + `active` near `maxPoolSize` indicates executor is overloaded.
+
+2) Async exception counters:
+- `registry.async.exceptions{type="completion|execution|illegalargument", cause="<ExceptionClass>", status="<http-status>"}`
+
+Examples of metric labels:
+- `registry.async.exceptions{type="completion",cause="NullPointerException",status="503"}`
+- `registry.async.exceptions{type="completion",cause="IllegalArgumentException",status="400"}`
+
+Notes about labels:
+- `type` indicates which top-level exception handler saw the exception (e.g. CompletionException).
+- `cause` is the simple class name of the nested cause when available.
+- `status` is the HTTP status code chosen by the `AsyncExceptionHandler` mapping.
+
+Prometheus scraping
+-------------------
+If your application exposes Micrometer metrics via a Prometheus endpoint (e.g. Spring Boot Actuator ` /actuator/prometheus`), add a scrape job in Prometheus configuration pointing to that endpoint. Example `prometheus.yml` snippet:
+
+```yaml
+scrape_configs:
+  - job_name: 'registry-ws'
+    static_configs:
+      - targets: ['registry-host:port']
+    metrics_path: /actuator/prometheus
+```
+
+Grafana / Prometheus queries examples
+------------------------------------
+- Current active threads: `registry_async_executor_active`
+- Executor queue size: `registry_async_executor_queueSize`
+- Exceptions per minute (all types):
+```
+rate(registry_async_exceptions[1m])
+```
+- Exceptions filtered by status 503 in last 5m:
+```
+sum(rate(registry_async_exceptions{status="503"}[5m])) by (cause)
+```
+
+(Depending on your Prometheus metrics naming normalization you may need to replace dots with underscores; the Prometheus exporter used by Micrometer transforms metric names. The examples above assume the direct mapping; adapt queries by inspecting the `/actuator/prometheus` payload.)
+
+Operational guidance and tuning
+--------------------------------
+- Start with conservative settings (e.g. core 10, max 50, queue 500) and increase based on CPU and I/O characteristics. If tasks are blocking (I/O, DB calls, external APIs) you may need more threads but watch memory.
+- Monitor `registry.async.executor.queueSize` and `registry.async.executor.active`. If queue grows steadily, either increase capacity or reduce incoming load.
+- Consider adding a `RejectedExecutionHandler` policy if you want immediate backpressure (e.g. `CallerRunsPolicy` or a custom handler that increments metrics and returns HTTP 429/503). The current implementation does not install a custom RejectedExecutionHandler.
+- The `boundedTaskExecutor` bean is injected optionally; ensure the bean is available on the profile you run in production.
+
+AsyncExceptionHandler and HTTP mapping
+-------------------------------------
+- There is a `ControllerAdvice` (`AsyncExceptionHandler`) that maps `CompletionException` / `ExecutionException` and nested causes into HTTP responses. It also increments `registry.async.exceptions` counters with labels for `type`, `cause` and `status`.
+- The default mappings implemented are:
+  - `IllegalArgumentException` -> HTTP 400 (Bad Request)
+  - other nested causes -> HTTP 503 (Service Unavailable)
+
+If you prefer more specific mappings (timeouts -> 504, connection refused -> 502), update the `AsyncExceptionHandler` to inspect nested causes (e.g. `SocketTimeoutException`, `ConnectException`) and map accordingly.
+
+Next steps / suggestions
+------------------------
+- If you only use Prometheus, ensure Micrometer's Prometheus registry is on the classpath and the `/actuator/prometheus` endpoint or an equivalent is exposed for scraping.
+- Optionally implement a `RejectedExecutionHandler` that records a metric and returns an immediate error to callers when the executor is saturated.
+- If you want, I can perform a repo-wide replacement of all remaining `CompletableFuture.supplyAsync(...)` calls to pass the `boundedTaskExecutor` explicitly and compile.
+
+Location
+--------
+This README was added at:
+`/Users/xrc439/dev/gbif/registry/registry-ws/ASYNC_EXECUTOR_README.md`
+
+
+If you want any edits to this README (more Prometheus/Grafana examples, JSON error body samples, or a sample Alertmanager rule for saturated executor), tell me which items to add and I'll update the file.
+

--- a/registry-ws/ASYNC_EXECUTOR_README.md
+++ b/registry-ws/ASYNC_EXECUTOR_README.md
@@ -17,9 +17,9 @@ The executor can be tuned via the following configuration keys (defaults shown):
 # Tune the bounded task executor
 registry:
   async:
-    corePoolSize: 20
-    maxPoolSize: 100
-    queueCapacity: 1000
+    corePoolSize: 10
+    maxPoolSize: 50
+    queueCapacity: 500
 ```
 
 If you use Spring Boot, these configuration keys can also be set as environment variables by converting the property path to uppercase with dots replaced by underscores, e.g. `REGISTRY_ASYNC_COREPOOLSIZE`.

--- a/registry-ws/ASYNC_EXECUTOR_README.md
+++ b/registry-ws/ASYNC_EXECUTOR_README.md
@@ -44,7 +44,7 @@ Exposed metric names and labels (as registered by the code):
 These are simple numeric gauges and are useful to detect saturation: growing `queueSize` + `active` near `maxPoolSize` indicates executor is overloaded.
 
 2) Async exception counters:
-- `registry.async.exceptions{type="completion|execution|illegalargument", cause="<ExceptionClass>", status="<http-status>"}`
+- `registry.async.exceptions{type="completion|execution|illegal_argument", cause="<ExceptionClass>", status="<http-status>"}`
 
 Examples of metric labels:
 - `registry.async.exceptions{type="completion",cause="NullPointerException",status="503"}`

--- a/registry-ws/ASYNC_EXECUTOR_README.md
+++ b/registry-ws/ASYNC_EXECUTOR_README.md
@@ -107,7 +107,7 @@ Next steps / suggestions
 Location
 --------
 This README was added at:
-`/Users/xrc439/dev/gbif/registry/registry-ws/ASYNC_EXECUTOR_README.md`
+`registry-ws/ASYNC_EXECUTOR_README.md`
 
 
 If you want any edits to this README (more Prometheus/Grafana examples, JSON error body samples, or a sample Alertmanager rule for saturated executor), tell me which items to add and I'll update the file.

--- a/registry-ws/pom.xml
+++ b/registry-ws/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.gbif.registry</groupId>
     <artifactId>registry-parent</artifactId>
-    <version>4.2.20-SNAPSHOT</version>
+    <version>4.2.20-issue-801-async-calls-SNAPSHOT</version>
   </parent>
   <artifactId>registry-ws</artifactId>
   <name>GBIF Registry Webservices</name>

--- a/registry-ws/src/main/java/org/gbif/registry/ws/config/AsyncConfig.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/config/AsyncConfig.java
@@ -13,10 +13,16 @@
  */
 package org.gbif.registry.ws.config;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import java.util.concurrent.Executor;
+import io.micrometer.core.instrument.MeterRegistry;
 
 @Profile("!test")
 @Configuration
@@ -25,5 +31,35 @@ public class AsyncConfig {
 
   public AsyncConfig() {
     SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL);
+  }
+
+  @Value("${registry.async.corePoolSize:10}")
+  private int corePoolSize;
+
+  @Value("${registry.async.maxPoolSize:50}")
+  private int maxPoolSize;
+
+  @Value("${registry.async.queueCapacity:500}")
+  private int queueCapacity;
+
+  @Bean
+  @Qualifier("boundedTaskExecutor")
+  public Executor boundedTaskExecutor(@org.springframework.beans.factory.annotation.Autowired(required = false) MeterRegistry registry) {
+    ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+    executor.setCorePoolSize(corePoolSize);
+    executor.setMaxPoolSize(maxPoolSize);
+    executor.setQueueCapacity(queueCapacity);
+    executor.setThreadNamePrefix("gbif-dataset-async-");
+    executor.initialize();
+
+    // register gauges to monitor executor
+    java.util.concurrent.ThreadPoolExecutor pool = executor.getThreadPoolExecutor();
+    if (pool != null && registry != null) {
+      registry.gauge("registry.async.executor.active", pool, p -> (double) p.getActiveCount());
+      registry.gauge("registry.async.executor.poolSize", pool, p -> (double) p.getPoolSize());
+      registry.gauge("registry.async.executor.queueSize", pool.getQueue(), q -> (double) q.size());
+    }
+
+    return executor;
   }
 }

--- a/registry-ws/src/main/java/org/gbif/registry/ws/config/AsyncConfig.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/config/AsyncConfig.java
@@ -13,6 +13,9 @@
  */
 package org.gbif.registry.ws.config;
 
+import java.util.concurrent.ThreadPoolExecutor;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -44,7 +47,7 @@ public class AsyncConfig {
 
   @Bean
   @Qualifier("boundedTaskExecutor")
-  public Executor boundedTaskExecutor(@org.springframework.beans.factory.annotation.Autowired(required = false) MeterRegistry registry) {
+  public Executor boundedTaskExecutor(@Autowired(required = false) MeterRegistry registry) {
     ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(corePoolSize);
     executor.setMaxPoolSize(maxPoolSize);
@@ -53,8 +56,8 @@ public class AsyncConfig {
     executor.initialize();
 
     // register gauges to monitor executor
-    java.util.concurrent.ThreadPoolExecutor pool = executor.getThreadPoolExecutor();
-    if (pool != null && registry != null) {
+    ThreadPoolExecutor pool = executor.getThreadPoolExecutor();
+    if (registry != null) {
       registry.gauge("registry.async.executor.active", pool, p -> (double) p.getActiveCount());
       registry.gauge("registry.async.executor.poolSize", pool, p -> (double) p.getPoolSize());
       registry.gauge("registry.async.executor.queueSize", pool.getQueue(), q -> (double) q.size());

--- a/registry-ws/src/main/java/org/gbif/registry/ws/exception/AsyncExceptionHandler.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/exception/AsyncExceptionHandler.java
@@ -63,11 +63,5 @@ public class AsyncExceptionHandler {
     String message = cause == null ? ex.getMessage() : cause.getMessage();
     return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(message);
   }
-
-  @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
-    meterRegistry.counter("registry.async.exceptions", "type", "illegal_argument", "cause", ex.getClass().getSimpleName(), "status", "400").increment();
-    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
-  }
 }
 

--- a/registry-ws/src/main/java/org/gbif/registry/ws/exception/AsyncExceptionHandler.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/exception/AsyncExceptionHandler.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gbif.registry.ws.exception;
 
 import java.util.concurrent.CompletionException;

--- a/registry-ws/src/main/java/org/gbif/registry/ws/exception/AsyncExceptionHandler.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/exception/AsyncExceptionHandler.java
@@ -1,0 +1,60 @@
+package org.gbif.registry.ws.exception;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+/**
+ * Global handler for exceptions propagated from async controller methods returning CompletableFuture.
+ */
+@ControllerAdvice
+public class AsyncExceptionHandler {
+
+  private final MeterRegistry meterRegistry;
+
+  public AsyncExceptionHandler(@Autowired(required = false) MeterRegistry meterRegistry) {
+    // fall back to a simple noop registry when none is provided to avoid failing bean creation
+    this.meterRegistry = meterRegistry != null ? meterRegistry : new SimpleMeterRegistry();
+  }
+
+  @ExceptionHandler(CompletionException.class)
+  public ResponseEntity<String> handleCompletionException(CompletionException ex) {
+    Throwable cause = ex.getCause();
+    String causeClass = cause == null ? "unknown" : cause.getClass().getSimpleName();
+    if (cause instanceof IllegalArgumentException) {
+      meterRegistry.counter("registry.async.exceptions", "type", "completion", "cause", causeClass, "status", "400").increment();
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(cause.getMessage());
+    }
+    meterRegistry.counter("registry.async.exceptions", "type", "completion", "cause", causeClass, "status", "503").increment();
+    String message = cause == null ? ex.getMessage() : cause.getMessage();
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(message);
+  }
+
+  @ExceptionHandler(ExecutionException.class)
+  public ResponseEntity<String> handleExecutionException(ExecutionException ex) {
+    Throwable cause = ex.getCause();
+    String causeClass = cause == null ? "unknown" : cause.getClass().getSimpleName();
+    if (cause instanceof IllegalArgumentException) {
+      meterRegistry.counter("registry.async.exceptions", "type", "execution", "cause", causeClass, "status", "400").increment();
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(cause.getMessage());
+    }
+    meterRegistry.counter("registry.async.exceptions", "type", "execution", "cause", causeClass, "status", "503").increment();
+    String message = cause == null ? ex.getMessage() : cause.getMessage();
+    return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(message);
+  }
+
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<String> handleIllegalArgument(IllegalArgumentException ex) {
+    meterRegistry.counter("registry.async.exceptions", "type", "illegal_argument", "cause", ex.getClass().getSimpleName(), "status", "400").increment();
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+  }
+}
+

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
@@ -96,6 +96,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 import jakarta.annotation.Nullable;
@@ -175,7 +176,7 @@ import static org.gbif.registry.security.UserRoles.IPT_ROLE;
 @RestController
 @RequestMapping(value = "dataset", produces = MediaType.APPLICATION_JSON_VALUE)
 public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetListParams>
-    implements DatasetService, DatasetSearchService, DatasetProcessStatusService {
+    implements DatasetService, DatasetProcessStatusService {
 
   private static final Logger LOG = LoggerFactory.getLogger(DatasetResource.class);
 
@@ -190,6 +191,7 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
 
   private final RegistryDatasetService registryDatasetService;
   private final DatasetSearchService searchService;
+  private final org.gbif.registry.search.dataset.service.AsyncDatasetSearchService asyncSearchService;
   private final MetadataMapper metadataMapper;
   private final DatasetMapper datasetMapper;
   private final ContactMapper contactMapper;
@@ -207,12 +209,14 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
   // The messagePublisher can be optional
   private final MessagePublisher messagePublisher;
   private final ConceptClient conceptClient;
+  private final Executor asyncExecutor;
 
   public DatasetResource(
       MapperServiceLocator mapperServiceLocator,
       EventManager eventManager,
       RegistryDatasetService registryDatasetService,
       @Qualifier("datasetSearchServiceEs") DatasetSearchService searchService,
+      @Qualifier("datasetSearchServiceEs") org.gbif.registry.search.dataset.service.AsyncDatasetSearchService asyncSearchService,
       DatasetDoiDataCiteHandlingService doiDataCiteHandlingService,
       DataCiteMetadataBuilderService metadataBuilderService,
       DoiIssuingService doiIssuingService,
@@ -220,7 +224,8 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
       WithMyBatis withMyBatis,
       @Autowired(required = false) MessagePublisher messagePublisher,
       ConceptClient conceptClient,
-      jakarta.validation.Validator validator) {
+      jakarta.validation.Validator validator,
+      @Autowired(required = false) @Qualifier("boundedTaskExecutor") Executor asyncExecutor) {
     super(
         mapperServiceLocator.getDatasetMapper(),
         mapperServiceLocator,
@@ -230,6 +235,7 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
         validator);
     this.registryDatasetService = registryDatasetService;
     this.searchService = searchService;
+    this.asyncSearchService = asyncSearchService;
     this.metadataMapper = mapperServiceLocator.getMetadataMapper();
     this.datasetMapper = mapperServiceLocator.getDatasetMapper();
     this.contactMapper = mapperServiceLocator.getContactMapper();
@@ -245,6 +251,7 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
     this.withMyBatis = withMyBatis;
     this.emlWriter = EMLWriter.newInstance(false);
     this.conceptClient = conceptClient;
+    this.asyncExecutor = asyncExecutor;
   }
 
   @Target({ElementType.METHOD, ElementType.TYPE})
@@ -420,10 +427,16 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
   @ApiResponse(responseCode = "400", description = "Invalid search query provided")
   @Docs.DefaultUnsuccessfulReadResponses
   @GetMapping("search")
-  @Override
-  public SearchResponse<DatasetSearchResult, DatasetSearchParameter> search(
+  public java.util.concurrent.CompletableFuture<SearchResponse<DatasetSearchResult, DatasetSearchParameter>> search(
       DatasetSearchRequest searchRequest) {
-    return searchService.search(searchRequest);
+    // Prefer async service to avoid blocking servlet threads. Falls back to sync service if async not available.
+    if (asyncSearchService != null) {
+      return asyncSearchService.searchAsync(searchRequest);
+    }
+    if (asyncExecutor != null) {
+      return java.util.concurrent.CompletableFuture.supplyAsync(() -> searchService.search(searchRequest), asyncExecutor);
+    }
+    return java.util.concurrent.CompletableFuture.supplyAsync(() -> searchService.search(searchRequest));
   }
 
   @Operation(
@@ -473,9 +486,15 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
   @ApiResponse(responseCode = "400", description = "Invalid search query provided")
   @Docs.DefaultUnsuccessfulReadResponses
   @GetMapping("suggest")
-  @Override
-  public List<DatasetSuggestResult> suggest(DatasetSuggestRequest suggestRequest) {
-    return searchService.suggest(suggestRequest);
+  public java.util.concurrent.CompletableFuture<java.util.List<DatasetSuggestResult>> suggest(
+      DatasetSuggestRequest suggestRequest) {
+    if (asyncSearchService != null) {
+      return asyncSearchService.suggestAsync(suggestRequest);
+    }
+    if (asyncExecutor != null) {
+      return java.util.concurrent.CompletableFuture.supplyAsync(() -> searchService.suggest(suggestRequest), asyncExecutor);
+    }
+    return java.util.concurrent.CompletableFuture.supplyAsync(() -> searchService.suggest(suggestRequest));
   }
 
   @Operation(
@@ -1538,11 +1557,20 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
   public void crawlAll(
       @RequestParam(value = "platform", required = false) String platform,
       @Nullable CrawlAllParams crawlAllParams) {
-    CompletableFuture.runAsync(
-        () ->
-            doOnAllOccurrenceDatasets(
-                dataset -> crawl(dataset.getKey(), platform),
-                crawlAllParams != null ? crawlAllParams.datasetsToExclude : null));
+    if (asyncExecutor != null) {
+      CompletableFuture.runAsync(
+          () ->
+              doOnAllOccurrenceDatasets(
+                  dataset -> crawl(dataset.getKey(), platform),
+                  crawlAllParams != null ? crawlAllParams.datasetsToExclude : null),
+          asyncExecutor);
+    } else {
+      CompletableFuture.runAsync(
+          () ->
+              doOnAllOccurrenceDatasets(
+                  dataset -> crawl(dataset.getKey(), platform),
+                  crawlAllParams != null ? crawlAllParams.datasetsToExclude : null));
+    }
   }
 
   /**

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
@@ -217,7 +217,7 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
       EventManager eventManager,
       RegistryDatasetService registryDatasetService,
       @Qualifier("datasetSearchServiceEs") DatasetSearchService searchService,
-      @Qualifier("datasetSearchServiceEs") org.gbif.registry.search.dataset.service.AsyncDatasetSearchService asyncSearchService,
+      @Autowired(required = false) @Qualifier("datasetSearchServiceEs") org.gbif.registry.search.dataset.service.AsyncDatasetSearchService asyncSearchService,
       DatasetDoiDataCiteHandlingService doiDataCiteHandlingService,
       DataCiteMetadataBuilderService metadataBuilderService,
       DoiIssuingService doiIssuingService,

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/DatasetResource.java
@@ -66,6 +66,7 @@ import org.gbif.registry.persistence.mapper.params.DatasetListParams;
 import org.gbif.registry.persistence.mapper.params.NetworkListParams;
 import org.gbif.registry.persistence.mapper.pipelines.PipelineProcessMapper;
 import org.gbif.registry.persistence.service.MapperServiceLocator;
+import org.gbif.registry.search.dataset.service.AsyncDatasetSearchService;
 import org.gbif.registry.service.RegistryDatasetService;
 import org.gbif.registry.service.WithMyBatis;
 import org.gbif.registry.service.collections.utils.Vocabularies;
@@ -191,7 +192,7 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
 
   private final RegistryDatasetService registryDatasetService;
   private final DatasetSearchService searchService;
-  private final org.gbif.registry.search.dataset.service.AsyncDatasetSearchService asyncSearchService;
+  private final AsyncDatasetSearchService asyncSearchService;
   private final MetadataMapper metadataMapper;
   private final DatasetMapper datasetMapper;
   private final ContactMapper contactMapper;
@@ -427,16 +428,16 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
   @ApiResponse(responseCode = "400", description = "Invalid search query provided")
   @Docs.DefaultUnsuccessfulReadResponses
   @GetMapping("search")
-  public java.util.concurrent.CompletableFuture<SearchResponse<DatasetSearchResult, DatasetSearchParameter>> search(
+  public CompletableFuture<SearchResponse<DatasetSearchResult, DatasetSearchParameter>> search(
       DatasetSearchRequest searchRequest) {
     // Prefer async service to avoid blocking servlet threads. Falls back to sync service if async not available.
     if (asyncSearchService != null) {
       return asyncSearchService.searchAsync(searchRequest);
     }
     if (asyncExecutor != null) {
-      return java.util.concurrent.CompletableFuture.supplyAsync(() -> searchService.search(searchRequest), asyncExecutor);
+      return CompletableFuture.supplyAsync(() -> searchService.search(searchRequest), asyncExecutor);
     }
-    return java.util.concurrent.CompletableFuture.supplyAsync(() -> searchService.search(searchRequest));
+    return CompletableFuture.supplyAsync(() -> searchService.search(searchRequest));
   }
 
   @Operation(
@@ -492,9 +493,9 @@ public class DatasetResource extends BaseNetworkEntityResource<Dataset, DatasetL
       return asyncSearchService.suggestAsync(suggestRequest);
     }
     if (asyncExecutor != null) {
-      return java.util.concurrent.CompletableFuture.supplyAsync(() -> searchService.suggest(suggestRequest), asyncExecutor);
+      return CompletableFuture.supplyAsync(() -> searchService.suggest(suggestRequest), asyncExecutor);
     }
-    return java.util.concurrent.CompletableFuture.supplyAsync(() -> searchService.suggest(suggestRequest));
+    return CompletableFuture.supplyAsync(() -> searchService.suggest(suggestRequest));
   }
 
   @Operation(

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/external/IDigBioExternalResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/external/IDigBioExternalResource.java
@@ -13,6 +13,8 @@
  */
 package org.gbif.registry.ws.resources.external;
 
+import java.util.concurrent.Executor;
+
 import org.gbif.api.annotation.NullToNotFound;
 import org.gbif.api.model.collections.AlternativeCode;
 import org.gbif.api.vocabulary.Country;
@@ -37,6 +39,8 @@ import java.util.stream.Collectors;
 import jakarta.annotation.Nullable;
 
 import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -61,9 +65,9 @@ public class IDigBioExternalResource {
   private final java.util.concurrent.Executor asyncExecutor;
 
   public IDigBioExternalResource(IDigBioMapper idigBioMapper,
-      @org.springframework.beans.factory.annotation.Autowired(required = false)
-          @org.springframework.beans.factory.annotation.Qualifier("boundedTaskExecutor")
-          java.util.concurrent.Executor asyncExecutor) {
+          @Autowired(required = false)
+          @Qualifier("boundedTaskExecutor")
+          Executor asyncExecutor) {
     this.idigBioMapper = idigBioMapper;
     this.asyncExecutor = asyncExecutor;
   }

--- a/registry-ws/src/main/java/org/gbif/registry/ws/resources/external/IDigBioExternalResource.java
+++ b/registry-ws/src/main/java/org/gbif/registry/ws/resources/external/IDigBioExternalResource.java
@@ -58,9 +58,14 @@ import io.swagger.v3.oas.annotations.Hidden;
 public class IDigBioExternalResource {
 
   private final IDigBioMapper idigBioMapper;
+  private final java.util.concurrent.Executor asyncExecutor;
 
-  public IDigBioExternalResource(IDigBioMapper idigBioMapper) {
+  public IDigBioExternalResource(IDigBioMapper idigBioMapper,
+      @org.springframework.beans.factory.annotation.Autowired(required = false)
+          @org.springframework.beans.factory.annotation.Qualifier("boundedTaskExecutor")
+          java.util.concurrent.Executor asyncExecutor) {
     this.idigBioMapper = idigBioMapper;
+    this.asyncExecutor = asyncExecutor;
   }
 
   @NullToNotFound
@@ -74,11 +79,17 @@ public class IDigBioExternalResource {
     }
 
     CompletableFuture<List<MachineTagDto>> machineTagsDtoFuture =
-        CompletableFuture.supplyAsync(() -> idigBioMapper.getIDigBioMachineTags(collectionKeys));
+        asyncExecutor != null
+            ? CompletableFuture.supplyAsync(() -> idigBioMapper.getIDigBioMachineTags(collectionKeys), asyncExecutor)
+            : CompletableFuture.supplyAsync(() -> idigBioMapper.getIDigBioMachineTags(collectionKeys));
     CompletableFuture<List<IdentifierDto>> identifiersDtoFuture =
-        CompletableFuture.supplyAsync(() -> idigBioMapper.getIdentifiers(collectionKeys));
+        asyncExecutor != null
+            ? CompletableFuture.supplyAsync(() -> idigBioMapper.getIdentifiers(collectionKeys), asyncExecutor)
+            : CompletableFuture.supplyAsync(() -> idigBioMapper.getIdentifiers(collectionKeys));
     CompletableFuture<List<IDigBioCollectionDto>> collectionsDtoFuture =
-        CompletableFuture.supplyAsync(() -> idigBioMapper.getCollections(collectionKeys));
+        asyncExecutor != null
+            ? CompletableFuture.supplyAsync(() -> idigBioMapper.getCollections(collectionKeys), asyncExecutor)
+            : CompletableFuture.supplyAsync(() -> idigBioMapper.getCollections(collectionKeys));
 
     CompletableFuture.allOf(collectionsDtoFuture, machineTagsDtoFuture, identifiersDtoFuture)
         .join();
@@ -145,14 +156,23 @@ public class IDigBioExternalResource {
     UUID collectionKey = collections.iterator().next();
 
     CompletableFuture<List<IDigBioCollectionDto>> collectionsDtoFuture =
-        CompletableFuture.supplyAsync(
-            () -> idigBioMapper.getCollections(Collections.singleton(collectionKey)));
+        asyncExecutor != null
+            ? CompletableFuture.supplyAsync(
+                () -> idigBioMapper.getCollections(Collections.singleton(collectionKey)), asyncExecutor)
+            : CompletableFuture.supplyAsync(
+                () -> idigBioMapper.getCollections(Collections.singleton(collectionKey)));
     CompletableFuture<List<MachineTagDto>> machineTagsDtoFuture =
-        CompletableFuture.supplyAsync(
-            () -> idigBioMapper.getIDigBioMachineTags(Collections.singleton(collectionKey)));
+        asyncExecutor != null
+            ? CompletableFuture.supplyAsync(
+                () -> idigBioMapper.getIDigBioMachineTags(Collections.singleton(collectionKey)), asyncExecutor)
+            : CompletableFuture.supplyAsync(
+                () -> idigBioMapper.getIDigBioMachineTags(Collections.singleton(collectionKey)));
     CompletableFuture<List<IdentifierDto>> identifiersDtoFuture =
-        CompletableFuture.supplyAsync(
-            () -> idigBioMapper.getIdentifiers(Collections.singleton(collectionKey)));
+        asyncExecutor != null
+            ? CompletableFuture.supplyAsync(
+                () -> idigBioMapper.getIdentifiers(Collections.singleton(collectionKey)), asyncExecutor)
+            : CompletableFuture.supplyAsync(
+                () -> idigBioMapper.getIdentifiers(Collections.singleton(collectionKey)));
 
     CompletableFuture.allOf(collectionsDtoFuture, machineTagsDtoFuture, identifiersDtoFuture)
         .join();


### PR DESCRIPTION
Main changes:

1. Add a configurable bounded ThreadPoolTaskExecutor bean (qualifier boundedTaskExecutor) and register Micrometer gauges to monitor:
```
registry.async.executor.active
registry.async.executor.poolSize
registry.async.executor.queueSize 
```
Configuration keys(FileAsyncConfig.java): 
```
registry.async.corePoolSize
registry.async.maxPoolSize 
registry.async.queueCapacity
```
2. Wire the bounded executor into controller/resource fallbacks so blocking async fallbacks use the bounded pool instead of the common ForkJoinPool. These use optional injection to remain backwards compatible if the bean isn't present:
DatasetResource.java
3. Update external async usage to use the bounded executor (where appropriate) so parallel mapper calls do not spawn uncontrolled threads: IDigBioExternalResource.java
4. Add AsyncExceptionHandler (@ControllerAdvice) to convert CompletionException/ExecutionException/IllegalArgumentException from CompletableFuture endpoints into deterministic HTTP responses and record async-exception counters:
    - AsyncExceptionHandler.java 
    - Metric: registry.async.exceptions{type, cause, status}
5. Document the new executor, configuration and Prometheus/Micrometer metrics in: ASYNC_EXECUTOR_README.md