### PR TITLE
[fix] Split integration-test by profile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
                   ]) {
                     sh '''
                        mvn -B -Denforcer.skip=true -Dappkeys.testfile=$APPKEYS_TESTFILE clean install deploy verify -T 1C \
-                           -Dparallel=classes -DuseUnlimitedThreads=true -Pgbif-dev,registry-cli-it,secrets-dev -U
+                           -Dparallel=classes -DuseUnlimitedThreads=true -Pgbif-dev,registry-cli-it,secrets-dev,integration-test -U
                       '''
                   }
             }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ As a distributed network, the registry serves a central coordination mechanism, 
 * PR are preferred for complex functionality. **Please target the dev branch**.
 * Simple changes can be committed without review.
 
+## Local Development
+
+### Building
+```mvn clean package```
+
+### Running unit tests
+```mvn verify```
+
+### Running integration tests
+Integration tests require Docker (Testcontainers for PostgreSQL and Elasticsearch).
+
+```mvn verify -Pintegration-tests```
+
+For development against real GBIF infrastructure (GBIF staff only), add the
+`registry-local` profile from [**registry-ws**](registry-ws/README.md) to your `~/.m2/settings.xml`
+and run:
+
+```mvn verify -Pintegration-tests,registry-local```
+
 ## Code style
 
 The registry uses the spotless-maven-plugin (import order, license header).

--- a/pom.xml
+++ b/pom.xml
@@ -1028,4 +1028,29 @@
     </pluginManagement>
   </build>
 
+  <!--
+    Circumvent Integration test blocking normal unit test, profile will automatically be disabled if any other
+    profile is activated using `mvn verify -Pregistry-cli-it` or similar.
+  -->
+  <profiles>
+    <profile>
+      <id>registry-test-defaults</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <mail.cc></mail.cc>
+        <mail.bcc></mail.bcc>
+        <mail.from>test@example.com</mail.from>
+        <mail.helpdesk>test@example.com</mail.helpdesk>
+        <directory.app.key>gbif.app.it</directory.app.key>
+        <directory.app.secret>fake</directory.app.secret>
+        <directory.ws.url>http://localhost/directory/</directory.ws.url>
+        <validation.client.username>test</validation.client.username>
+        <validation.client.password>fake</validation.client.password>
+        <appkeys.testfile>${project.basedir}/src/test/resources/appkeys-test.properties</appkeys.testfile>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>

--- a/registry-integration-tests/README.md
+++ b/registry-integration-tests/README.md
@@ -1,22 +1,31 @@
 # GBIF Registry Integration Tests
 
-This module includes integration tests for all the registry modules.
-Internally using [JUnit](https://junit.org/junit5/),
-[Mockito](https://site.mockito.org/) and
-testcontainers.
+Integration tests for all registry modules using JUnit 5, Mockito, and
+Testcontainers (PostgreSQL + Elasticsearch — Docker required).
 
- ## Run tests by maven
+## Running
 
- ```mvn clean verify```
+### Unit tests only (no Docker, no external dependencies)
+```mvn verify```
 
- ## Run by Intellij IDEA
+### Integration tests (requires Docker)
+```mvn verify -Pintegration-tests```
 
- Right click on java directory -> Run 'All Tests'
+### Against real GBIF infrastructure (GBIF staff only)
+Add the `registry-local` profile to `~/.m2/settings.xml` (see `registry-ws/README.md`),
+then:
+```mvn verify -Pintegration-tests,registry-local```
 
- Right click on specific test class -> Run 'ThisIT'
+## Configuration
 
- ## Configuration
+Test properties are in `src/test/resources/application-test.yml`.
 
- Test properties can be configured in file [application-test.yml](src/test/resources/application-test.yml).
+Safe default values for all properties are provided automatically via the
+`registry-test-defaults` Maven profile in the root pom. No `settings.xml`
+configuration is needed to run tests locally.
 
-[Parent](../README.md)
+## IntelliJ IDEA
+
+Right click `src/test/java` → Run 'All Tests'
+
+Right click a specific test class → Run 'TestClassNameIT'

--- a/registry-integration-tests/pom.xml
+++ b/registry-integration-tests/pom.xml
@@ -286,6 +286,12 @@
             <exclude>**/*Tests.java</exclude>
           </excludes>
         </configuration>
+        <executions>
+          <execution>
+            <id>default</id>
+            <phase>none</phase>  <!-- Do not run Integration tests during normal `mvn verify` -->
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
@@ -324,4 +330,29 @@
     </plugins>
   </build>
 
+  <!--
+    Activating the integration-test profile, will include Integration tests
+  -->
+  <profiles>
+    <profile>
+      <id>integration-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration-tests</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/registry-integration-tests/src/test/resources/appkeys-test.properties
+++ b/registry-integration-tests/src/test/resources/appkeys-test.properties
@@ -1,0 +1,2 @@
+gbif.registry-ws-client-it=fake-secret-it
+gbif.app.it=a

--- a/registry-ws/README.md
+++ b/registry-ws/README.md
@@ -5,98 +5,112 @@ and Elasticsearch. Project uses [Spring Boot](https://github.com/spring-projects
 
 ## Building
 
-To build this project
-
- ```mvn clean package```
-
-Add this to local setting.xml (MacOS: `/Users/youruser/.m2/settings.xml`)
-
-````xml
-<!-- A profile that allows for local development -->
-        <profile>
-            <id>registry-local</id>
-            <properties>
-                <checklistbank-it-spring.db.url>jdbc:postgresql://builds.gbif.org:5432/clb_spring</checklistbank-it-spring.db.url>
-                <checklistbank-it-spring.db.name>checklistbank</checklistbank-it-spring.db.name>
-                <checklistbank-it-spring.db.username>checklistbank</checklistbank-it-spring.db.username>
-                <checklistbank-it-spring.db.password>%checklistbank_password%</checklistbank-it-spring.db.password>
-
-                <appkeys.file>/Users/youruser/dev/appkeys.properties</appkeys.file>
-                <api.url>http://api.gbif.org/v1/</api.url>
-                <portal.url>https://www.gbif-dev.org</portal.url>
-
-                <registry.postalservice.enabled>false</registry.postalservice.enabled>
-                <registry.messaging.hostname>mq.gbif.org</registry.messaging.hostname>
-                <registry.messaging.port>5672</registry.messaging.port>
-                <registry.messaging.virtualhost>/dev</registry.messaging.virtualhost>
-                <registry.messaging.username>doi</registry.messaging.username>
-                <registry.messaging.password>%queue_password%</registry.messaging.password>
-
-                <mail.devEmailForIdentity.enabled>true</mail.devEmailForIdentity.enabled>
-                <mail.devEmailForOrganizationsEndorsement.enabled>true</mail.devEmailForOrganizationsEndorsement.enabled>
-                <mail.devEmailForCollections.enabled>true</mail.devEmailForCollections.enabled>
-                <mail.devEmailForPipelines.enabled>true</mail.devEmailForPipelines.enabled>
-                <mail.smtp.host>smtp.gmail.com</mail.smtp.host>
-                <mail.smtp.port>587</mail.smtp.port>
-                <mail.cc></mail.cc>
-                <mail.bcc></mail.bcc>
-                <mail.from>youruser@gmail.com</mail.from>
-                <mail.username>youremail@gmail.com</mail.username>
-                <mail.password>%your_email_password%</mail.password>
-                <mail.helpdesk>gbifregistry@mailinator.com</mail.helpdesk>
-
-                <directory.ws.url>http://api.gbif-dev.org/v1/directory/</directory.ws.url>
-                <directory.app.key>gbif.portal</directory.app.key>
-                <directory.app.secret>%directory_app_secret%</directory.app.secret>
-
-                <datacite.api.base.url>https://api.test.datacite.org/</datacite.api.base.url>
-                <datacite.user>GBIF.GBIF</datacite.user>
-                <datacite.password>%datacite_password%</datacite.password>
-
-                <pipelines.do.all.threads>1</pipelines.do.all.threads>
-            </properties>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-        </profile>
-        <profile>
-            <id>registry-local-it</id>
-            <properties>
-                <registry-it.db.url>jdbc:postgresql://localhost:5432/registry_it</registry-it.db.url>
-                <registry-it.db.host>localhost</registry-it.db.host>
-                <registry-it.db.name>registry_it</registry-it.db.name>
-                <registry-it.db.username>mpodolskiy</registry-it.db.username>
-                <registry-it.db.password/>
-
-                <registry-it-spring.db.url>jdbc:postgresql://localhost:5432/registry_it</registry-it-spring.db.url>
-                <registry-it-spring.db.host>localhost</registry-it-spring.db.host>
-                <registry-it-spring.db.name>registry_it</registry-it-spring.db.name>
-                <registry-it-spring.db.username>mpodolskiy</registry-it-spring.db.username>
-                <registry-it-spring.db.password/>
-
-                <appkeys.testfile>/Users/youruser/dev/appkeys.properties</appkeys.testfile>
-            </properties>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-        </profile>
-````
-
- * Some passwords and secret properties are absent, see gbif-configuration.
-
- * Make sure database is already created (see [persitence module](../registry-persistence/README.md)).
-
- * Create appkeys.properties file under the path of property `appkeys.file` and `appkeys.testfile`
-
- * Gmail example configuartion (can be any).
+```mvn clean package```
 
 ## Running
-
-To run this project
 
 ```java -jar registry-ws/target/registry-ws-1.0-SNAPSHOT-exec.jar```
 
 Execute this command in root directory. Version may be different.
 
-[Parent](../README.md)
+## Local development against GBIF infrastructure (GBIF staff only)
 
+> **Not required** for building the project or running tests locally — those work
+> out of the box with safe defaults. Only needed to run against real GBIF dev
+> infrastructure or external services.
+
+Add the following profiles to your local `~/.m2/settings.xml`.
+
+> **Important:** Do not add `<activeByDefault>true</activeByDefault>` to these profiles.
+> Profiles must be activated explicitly to avoid silently pointing your build at
+> real GBIF infrastructure.
+
+```xml
+<profile>
+  <id>registry-local</id>
+  <properties>
+    <checklistbank-it-spring.db.url>jdbc:postgresql://builds.gbif.org:5432/clb_spring</checklistbank-it-spring.db.url>
+    <checklistbank-it-spring.db.name>checklistbank</checklistbank-it-spring.db.name>
+    <checklistbank-it-spring.db.username>checklistbank</checklistbank-it-spring.db.username>
+    <checklistbank-it-spring.db.password>FILL_ME_IN</checklistbank-it-spring.db.password>
+
+    <appkeys.file>/path/to/your/appkeys.properties</appkeys.file>
+    <api.url>http://api.gbif.org/v1/</api.url>
+    <portal.url>https://www.gbif-dev.org</portal.url>
+
+    <registry.postalservice.enabled>false</registry.postalservice.enabled>
+    <registry.messaging.hostname>mq.gbif.org</registry.messaging.hostname>
+    <registry.messaging.port>5672</registry.messaging.port>
+    <registry.messaging.virtualhost>/dev</registry.messaging.virtualhost>
+    <registry.messaging.username>doi</registry.messaging.username>
+    <registry.messaging.password>FILL_ME_IN</registry.messaging.password>
+
+    <mail.devEmailForIdentity.enabled>true</mail.devEmailForIdentity.enabled>
+    <mail.devEmailForOrganizationsEndorsement.enabled>true</mail.devEmailForOrganizationsEndorsement.enabled>
+    <mail.devEmailForCollections.enabled>true</mail.devEmailForCollections.enabled>
+    <mail.devEmailForPipelines.enabled>true</mail.devEmailForPipelines.enabled>
+    <mail.smtp.host>smtp.gmail.com</mail.smtp.host>
+    <mail.smtp.port>587</mail.smtp.port>
+    <mail.cc></mail.cc>
+    <mail.bcc></mail.bcc>
+    <mail.from>youruser@gmail.com</mail.from>
+    <mail.username>youruser@gmail.com</mail.username>
+    <mail.password>FILL_ME_IN</mail.password>
+    <mail.helpdesk>gbifregistry@mailinator.com</mail.helpdesk>
+
+    <directory.ws.url>http://api.gbif-dev.org/v1/directory/</directory.ws.url>
+    <directory.app.key>gbif.portal</directory.app.key>
+    <directory.app.secret>FILL_ME_IN</directory.app.secret>
+
+    <datacite.api.base.url>https://api.test.datacite.org/</datacite.api.base.url>
+    <datacite.user>GBIF.GBIF</datacite.user>
+    <datacite.password>FILL_ME_IN</datacite.password>
+
+    <pipelines.do.all.threads>1</pipelines.do.all.threads>
+  </properties>
+</profile>
+
+<profile>
+  <id>registry-local-it</id>
+  <properties>
+    <registry-it.db.url>jdbc:postgresql://localhost:5432/registry_it</registry-it.db.url>
+    <registry-it.db.host>localhost</registry-it.db.host>
+    <registry-it.db.name>registry_it</registry-it.db.name>
+    <registry-it.db.username>FILL_ME_IN</registry-it.db.username>
+    <registry-it.db.password/>
+
+    <registry-it-spring.db.url>jdbc:postgresql://localhost:5432/registry_it</registry-it-spring.db.url>
+    <registry-it-spring.db.host>localhost</registry-it-spring.db.host>
+    <registry-it-spring.db.name>registry_it</registry-it-spring.db.name>
+    <registry-it-spring.db.username>FILL_ME_IN</registry-it-spring.db.username>
+    <registry-it-spring.db.password/>
+
+    <appkeys.testfile>/path/to/your/appkeys.properties</appkeys.testfile>
+  </properties>
+</profile>
+```
+
+Secrets and passwords are not listed here — see gbif-configuration for the actual values.
+
+Make sure the database is already created before running (see [persistence module](../registry-persistence/README.md)).
+
+Create an `appkeys.properties` file at the path referenced by `appkeys.file` and `appkeys.testfile`.
+The file is a simple key=secret properties file, one app key per line.
+
+```properties
+gbif.portal=FILL_ME_IN
+gbif.registry-ws-client=FILL_ME_IN
+gbif.app.it=FILL_ME_IN
+```
+
+actual secrets are available in gbif-configuration
+
+### Running against GBIF dev infrastructure
+
+```mvn verify -Pintegration-tests,registry-local```
+
+### Running integration tests with a local database
+
+```mvn verify -Pintegration-tests,registry-local-it```
+
+[Parent](../README.md)


### PR DESCRIPTION
Before this PR, it was impossible to simply checkout the repository and run `mvn clean package`,
as `registry-integration-tests` was blocking the build due to failing tests caused by missing
configuration and/or no active Maven profile. The `application-test.yml` contained `@token@`
placeholders that were never substituted because no profile providing those properties was active.

This PR fixes that by:

- Making `mvn clean package` and `mvn verify` work directly from a clean checkout with no
  additional setup required.
- Splitting unit tests and integration tests following Maven conventions (Surefire vs Failsafe).
- Gating integration tests behind an explicit Maven profile — they now only run with
  `-Pintegration-tests`, e.g. `mvn verify -Pintegration-tests`.
- Adding a `registry-test-defaults` profile to the root pom that provides safe placeholder
  values for all `@token@` properties, so the build works without a `settings.xml`.
- Adding `appkeys-test.properties` to test resources so the `KeyStore` mock bean can
  initialize without a local file reference.
- Amending the `Jenkinsfile` to explicitly pass `-Pintegration-tests` (preserving existing
  CI behaviour).
- Updating `README.md` files so it is clear from the root that additional setup is required
  for integration tests, with a link to the `registry-ws` submodule README for details.